### PR TITLE
Adding Retailer Opening Hours feature.

### DIFF
--- a/Api/Data/RetailerTimeSlotInterface.php
+++ b/Api/Data/RetailerTimeSlotInterface.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Api\Data;
+
+/**
+ * Generic Interface for retailer time slots items
+ *
+ * @category Smile
+ * @package  Smile\StoreLocator
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+interface RetailerTimeSlotInterface
+{
+    /**
+     * The date field
+     */
+    const DATE_FIELD = 'date';
+
+    /**
+     * The day of week field
+     */
+    const DAY_OF_WEEK_FIELD = 'day_of_week';
+
+    /**
+     * @return string
+     */
+    public function getStartTime();
+
+    /**
+     * @return string
+     */
+    public function getEndTime();
+
+    /**
+     * Set the start time
+     *
+     * @param string $time The time
+     *
+     * @return mixed
+     */
+    public function setStartTime($time);
+
+    /**
+     * Set the end time
+     *
+     * @param string $time The time
+     *
+     * @return mixed
+     */
+    public function setEndTime($time);
+}

--- a/Block/Adminhtml/Retailer/OpeningHours.php
+++ b/Block/Adminhtml/Retailer/OpeningHours.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Block\Adminhtml\Retailer;
+
+use Magento\Framework\Stdlib\DateTime;
+use Smile\Retailer\Api\Data\RetailerInterface;
+
+/**
+ * Opening Hours rendering block
+ *
+ * @category Smile
+ * @package  Smile\StoreLocator
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class OpeningHours extends \Magento\Backend\Block\AbstractBlock
+{
+    /**
+     * @var \Magento\Framework\Data\FormFactory
+     */
+    private $formFactory;
+
+    /**
+     * @var \Magento\Framework\Registry
+     */
+    private $registry;
+
+    /**
+     * Constructor.
+     *
+     * @param \Magento\Backend\Block\Context      $context     Block context.
+     * @param \Magento\Framework\Data\FormFactory $formFactory Form factory.
+     * @param \Magento\Framework\Registry         $registry    Registry.
+     * @param array                               $data        Additional data.
+     */
+    public function __construct(
+        \Magento\Backend\Block\Context $context,
+        \Magento\Framework\Data\FormFactory $formFactory,
+        \Magento\Framework\Registry $registry,
+        array $data = []
+    ) {
+        $this->formFactory = $formFactory;
+        $this->registry = $registry;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     * {@inheritDoc}
+     */
+    protected function _toHtml()
+    {
+        return $this->escapeJsQuote($this->getForm()->toHtml());
+    }
+
+    /**
+     * Get retailer
+     *
+     * @return RetailerInterface
+     */
+    private function getRetailer()
+    {
+        return $this->registry->registry('current_seller');
+    }
+
+    /**
+     * Create the form containing the virtual rule field.
+     *
+     * @return \Magento\Framework\Data\Form
+     */
+    private function getForm()
+    {
+        $form = $this->formFactory->create();
+        $form->setHtmlId('opening_hours');
+
+        $openingHoursFieldset = $form->addFieldset(
+            'opening_hours',
+            ['name' => 'opening_hours', 'label' => __('Opening Hours'), 'container_id' => 'opening_hours']
+        );
+
+        if ($this->getRetailer() && $this->getRetailer()->getOpeningHours()) {
+            $openingHoursFieldset->setOpeningHours($this->getRetailer()->getOpeningHours());
+        }
+
+        $openingHoursRenderer = $this->getLayout()->createBlock('Smile\StoreLocator\Block\Adminhtml\Retailer\OpeningHours\Container\Renderer');
+        $openingHoursFieldset->setRenderer($openingHoursRenderer);
+
+        return $form;
+    }
+}

--- a/Block/Adminhtml/Retailer/OpeningHours/Container/Renderer.php
+++ b/Block/Adminhtml/Retailer/OpeningHours/Container/Renderer.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\Retailer
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Block\Adminhtml\Retailer\OpeningHours\Container;
+
+use Magento\Backend\Block\Template;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\Data\Form\Element\Renderer\RendererInterface;
+use Magento\Framework\Stdlib\DateTime;
+
+/**
+ * Opening Hours field renderer
+ *
+ * @SuppressWarnings(PHPMD.CamelCasePropertyName)
+ *
+ * @category Smile
+ * @package  Smile\Retailer
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Renderer extends Template implements RendererInterface
+{
+    /**
+     * @var \Magento\Framework\Data\Form\Element\Factory
+     */
+    protected $elementFactory;
+
+    /**
+     * @var AbstractElement
+     */
+    protected $element;
+
+    /**
+     * @var \Magento\Framework\Data\Form\Element\Text
+     */
+    protected $input;
+
+    /**
+     * @var string
+     */
+    protected $_template = 'retailer/openinghours/container.phtml';
+
+    /**
+     * @var \Magento\Framework\Locale\ListsInterface|null
+     */
+    private $localeList = null;
+
+    /**
+     * Block constructor.
+     *
+     * @param \Magento\Backend\Block\Template\Context      $context        Templating context.
+     * @param \Magento\Framework\Data\Form\Element\Factory $elementFactory Form element factory.
+     * @param \Magento\Framework\Locale\ListsInterface     $localeLists    Locale List.
+     * @param array                                        $data           Additional data.
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \Magento\Framework\Data\Form\Element\Factory $elementFactory,
+        \Magento\Framework\Locale\ListsInterface $localeLists,
+        array $data = []
+    ) {
+        $this->elementFactory = $elementFactory;
+        $this->localeList     = $localeLists;
+
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(AbstractElement $element)
+    {
+        $this->element = $element;
+        $this->element->addClass("opening-hours-container-fieldset");
+
+        return $this->toHtml();
+    }
+
+    /**
+     * Get currently edited element.
+     *
+     * @return AbstractElement
+     */
+    public function getElement()
+    {
+        return $this->element;
+    }
+
+    /**
+     * Retrieve element unique container id.
+     *
+     * @return string
+     */
+    public function getHtmlId()
+    {
+        return $this->getElement()->getContainer()->getHtmlId();
+    }
+
+    /**
+     * Render HTML of the element using the opening hours engine.
+     *
+     * @return string
+     */
+    public function getInputHtml()
+    {
+        if ($this->element->getOpeningHours()) {
+            $values = $this->element->getOpeningHours();
+        }
+
+        $html = "";
+        $days = $this->localeList->getOptionWeekdays(true, true);
+
+        foreach ($days as $key => $day) {
+            $input = $this->elementFactory->create('text');
+            $input->setForm($this->getElement()->getForm());
+
+            $elementRenderer = $this->getLayout()
+                ->createBlock('Smile\StoreLocator\Block\Adminhtml\Retailer\OpeningHours\Element\Renderer');
+
+            $elementRenderer->setDateFormat(DateTime::DATETIME_INTERNAL_FORMAT);
+
+            $input->setLabel(ucfirst($day['label']));
+            $input->setName($this->element->getName() . "[$key]");
+            $input->setRenderer($elementRenderer);
+
+            if (isset($values[$key])) {
+                $input->setValue($values[$key]);
+            }
+
+            $html .= $input->toHtml();
+        }
+
+        return $html;
+    }
+}

--- a/Block/Adminhtml/Retailer/OpeningHours/Element/Renderer.php
+++ b/Block/Adminhtml/Retailer/OpeningHours/Element/Renderer.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\Retailer
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Block\Adminhtml\Retailer\OpeningHours\Element;
+
+use Magento\Backend\Block\Template;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\Data\Form\Element\Renderer\RendererInterface;
+use Magento\Framework\Stdlib\DateTime;
+use Smile\StoreLocator\Api\Data\RetailerTimeSlotInterface;
+use Smile\StoreLocator\Api\Data\TimeSlotsInterface;
+use Zend_Date;
+
+/**
+ * Opening Hours field renderer
+ *
+ * @SuppressWarnings(PHPMD.CamelCasePropertyName)
+ *
+ * @category Smile
+ * @package  Smile\Retailer
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Renderer extends Template implements RendererInterface
+{
+    /**
+     * @var \Magento\Framework\Data\Form\Element\Factory
+     */
+    protected $elementFactory;
+
+    /**
+     * @var AbstractElement
+     */
+    protected $element;
+
+    /**
+     * @var \Magento\Framework\Data\Form\Element\Text
+     */
+    protected $input;
+
+    /**
+     * @var string
+     */
+    protected $_template = 'retailer/openinghours/element.phtml';
+
+    /**
+     * @var \Magento\Framework\Json\Helper\Data
+     */
+    private $jsonHelper;
+
+    /**
+     * Block constructor.
+     *
+     * @param \Magento\Backend\Block\Template\Context      $context        Templating context.
+     * @param \Magento\Framework\Data\Form\Element\Factory $elementFactory Form element factory.
+     * @param \Magento\Framework\Json\Helper\Data          $jsonHelper     Helper for JSON
+     * @param array                                        $data           Additional data.
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \Magento\Framework\Data\Form\Element\Factory $elementFactory,
+        \Magento\Framework\Json\Helper\Data $jsonHelper,
+        array $data = []
+    ) {
+        $this->elementFactory = $elementFactory;
+        $this->jsonHelper     = $jsonHelper;
+
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(AbstractElement $element)
+    {
+        $this->element = $element;
+        $this->input   = $this->elementFactory->create('hidden');
+        $this->input->setForm($this->getElement()->getForm());
+
+        $inputId = $this->getData("input_id") !== null ? $this->getData("input_id") : "opening_hours" . uniqid();
+
+        $this->input->setId($inputId);
+        $this->input->setName($element->getName());
+
+        $this->element->addClass("opening-hours-wrapper")->removeClass("admin__control-text");
+
+        return $this->toHtml();
+    }
+
+    /**
+     * Get currently edited element.
+     *
+     * @return AbstractElement
+     */
+    public function getElement()
+    {
+        return $this->element;
+    }
+
+    /**
+     * Retrieve element unique container id.
+     *
+     * @return string
+     */
+    public function getHtmlId()
+    {
+        return $this->input->getHtmlId();
+    }
+
+    /**
+     * Render HTML of the element using the opening hours engine.
+     *
+     * @return string
+     */
+    public function getInputHtml()
+    {
+        if ($this->element->getValue()) {
+            $this->input->setValue($this->getJsonValues());
+        }
+
+        return $this->input->toHtml();
+    }
+
+    /**
+     * Retrieve element values in Json.
+     *
+     * @return string
+     */
+    public function getJsonValues()
+    {
+        $values = $this->getValues();
+
+        return $this->jsonHelper->jsonEncode($values);
+    }
+
+    /**
+     * Retrieve element values
+     *
+     * @return array
+     */
+    private function getValues()
+    {
+        $values = [];
+        if ($this->element->getValue()) {
+            foreach ($this->element->getValue() as $timeSlot) {
+                $date      = new Zend_Date();
+                $startTime = $date->setTime($timeSlot->getStartTime())->toString(DateTime::DATETIME_INTERNAL_FORMAT);
+                $endTime   = $date->setTime($timeSlot->getEndTime())->toString(DateTime::DATETIME_INTERNAL_FORMAT);
+                $values[]  = [$startTime, $endTime];
+            }
+        }
+
+        return $values;
+    }
+}

--- a/Model/Data/RetailerTimeSlot.php
+++ b/Model/Data/RetailerTimeSlot.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Model\Data;
+
+use Magento\Framework\DataObject;
+use Smile\StoreLocator\Api\Data\RetailerTimeSlotInterface;
+
+/**
+ * Data Object for Time Slot entries.
+ *
+ * @category Smile
+ * @package  Smile\StoreLocator
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class RetailerTimeSlot extends DataObject implements RetailerTimeSlotInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getStartTime()
+    {
+        return $this->getData('start_time');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getEndTime()
+    {
+        return $this->getData('end_time');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setStartTime($time)
+    {
+        $this->setData('start_time', $time);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setEndTime($time)
+    {
+        $this->setData('end_time', $time);
+
+        return $this;
+    }
+}

--- a/Model/ResourceModel/RetailerTimeSlot.php
+++ b/Model/ResourceModel/RetailerTimeSlot.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\Stdlib\DateTime;
+use Smile\StoreLocator\Api\Data\RetailerTimeSlotInterface;
+use Zend_Date;
+
+/**
+ * Resource Model for Time Slots items (Eg. : Opening Hours)
+ *
+ * @category Smile
+ * @package  Smile\StoreLocator
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class RetailerTimeSlot extends AbstractDb
+{
+    /**
+     * Save time slots for a given retailer
+     *
+     * @param integer $retailerId    The retailer id
+     * @param null    $attributeCode The time slot type to store
+     * @param array   $timeSlots     The time slots to save, array based
+     *
+     * @return bool
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function saveTimeSlots($retailerId, $attributeCode, $timeSlots)
+    {
+        $data = [];
+        $this->deleteByRetailerId($retailerId, $attributeCode);
+
+        foreach ($timeSlots as $date => $timeSlotList) {
+            $dateField = is_numeric($date) ? RetailerTimeSlotInterface::DAY_OF_WEEK_FIELD : RetailerTimeSlotInterface::DATE_FIELD;
+
+            $row = [
+                "retailer_id"    => $retailerId,
+                "attribute_code" => $attributeCode,
+                $dateField       => $date,
+                "start_time"     => null,
+                "end_time"       => null,
+            ];
+
+            if (!count($timeSlotList)) {
+                $data[] = $row;
+                continue;
+            }
+
+            foreach ($timeSlotList as $timeSlot) {
+                $data[] = array_merge(
+                    $row,
+                    [
+                        'start_time' => $this->dateFromHour($timeSlot->getStartTime()),
+                        'end_time'   => $this->dateFromHour($timeSlot->getEndTime()),
+                    ]
+                );
+            }
+        }
+
+        $result = true;
+        if (!empty($data)) {
+            $result = (bool) $this->getConnection()->insertMultiple($this->getMainTable(), $data);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Retrieve all time slots of a given retailer
+     *
+     * @param integer $retailerId    The retailer id
+     * @param null    $attributeCode The time slot type to retrieve
+     *
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getTimeSlots($retailerId, $attributeCode)
+    {
+        $binds = [':retailer_id' => (int) $retailerId, ':attribute_code' => (string) $attributeCode];
+
+        $select = $this->getConnection()->select();
+        $select->from($this->getMainTable())
+            ->where("retailer_id = :retailer_id")
+            ->where("attribute_code = :attribute_code");
+
+        $timeSlotData = $this->getConnection()->fetchAll($select, $binds);
+
+        foreach ($timeSlotData as &$row) {
+            foreach (['start_time', 'end_time'] as $timeField) {
+                if (isset($row[$timeField]) && ($row[$timeField] !== null)) {
+                    $row[$timeField] = $this->dateToHour($row[$timeField]);
+                }
+            }
+        }
+
+        return $timeSlotData;
+    }
+
+    /**
+     * Delete Time Slots for a given retailer Id
+     *
+     * @param integer $retailerId    The retailer id
+     * @param null    $attributeCode The time slot type to delete, if any
+     *
+     * @return bool
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function deleteByRetailerId($retailerId, $attributeCode = null)
+    {
+        $deleteCondition = ["retailer_id = ?" => $retailerId];
+        if (null !== $attributeCode) {
+            $deleteCondition["attribute_code = ?"] = $attributeCode;
+        }
+
+        return (bool) $this->getConnection()->delete($this->getMainTable(), $deleteCondition);
+    }
+
+    /**
+     * Define main table name and attributes table
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName) The method is inherited
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init('smile_retailer_time_slots', 'retailer_id');
+    }
+
+    /**
+     * Build default date (01.01.1970) from an hour
+     *
+     * @param string $hour The hour
+     *
+     * @return string
+     */
+    private function dateFromHour($hour)
+    {
+        $date = new Zend_Date(0, Zend_Date::TIMESTAMP); // Init as 1970-01-01 since field is store on a DATETIME column.
+        $date->setTime($hour);
+
+        return $date->toString(DateTime::DATETIME_INTERNAL_FORMAT);
+    }
+
+    /**
+     * Extract hour from a date
+     *
+     * @param string $date The date
+     *
+     * @return string
+     */
+    private function dateToHour($date)
+    {
+        $date = new Zend_Date($date, DateTime::DATETIME_INTERNAL_FORMAT);
+
+        return $date->toString(Zend_Date::TIME_SHORT);
+    }
+}

--- a/Model/Retailer/OpeningHoursPostDataHandler.php
+++ b/Model/Retailer/OpeningHoursPostDataHandler.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Model\Retailer;
+
+use Smile\StoreLocator\Api\Data\RetailerTimeSlotInterfaceFactory;
+use Magento\Framework\Json\Helper\Data as JsonHelper;
+
+/**
+ * Post Data Handler for Retailer Opening Hours
+ *
+ * @category Smile
+ * @package  Smile\StoreLocator
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class OpeningHoursPostDataHandler implements \Smile\Retailer\Model\Retailer\PostDataHandlerInterface
+{
+    /**
+     * @var RetailerTimeSlotInterfaceFactory
+     */
+    private $timeSlotFactory;
+
+    /**
+     * @var JsonHelper
+     */
+    private $jsonHelper;
+
+    /**
+     * OpeningHoursPostDataHandler constructor.
+     *
+     * @param RetailerTimeSlotInterfaceFactory $timeSlotFactory Time Slot Factory
+     * @param JsonHelper                       $jsonHelper      JSON Helper
+     */
+    public function __construct(RetailerTimeSlotInterfaceFactory $timeSlotFactory, JsonHelper $jsonHelper)
+    {
+        $this->timeSlotFactory = $timeSlotFactory;
+        $this->jsonHelper      = $jsonHelper;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getData(\Smile\Retailer\Api\Data\RetailerInterface $retailer, $data)
+    {
+        if (isset($data['opening_hours'])) {
+            $openingHours = [];
+            foreach ($data['opening_hours'] as $date => &$timeSlotList) {
+                if (is_string($timeSlotList)) {
+                    try {
+                        $timeSlotList = $this->jsonHelper->jsonDecode($timeSlotList);
+                    } catch (\Zend_Json_Exception $exception) {
+                        $timeSlotList = [];
+                    }
+                }
+
+                if (!count($timeSlotList)) {
+                    continue;
+                }
+
+                foreach ($timeSlotList as $timeSlot) {
+                    $timeSlotModel = $this->timeSlotFactory->create(
+                        ['data' => ['start_time' => $timeSlot[0], 'end_time' => $timeSlot[1]]]
+                    );
+                    $openingHours[$date][] = $timeSlotModel;
+                }
+            }
+
+            $data['opening_hours'] = $openingHours;
+        }
+
+        return $data;
+    }
+}

--- a/Model/Retailer/OpeningHoursReadHandler.php
+++ b/Model/Retailer/OpeningHoursReadHandler.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Model\Retailer;
+
+use Magento\Framework\EntityManager\Operation\ExtensionInterface;
+use Smile\StoreLocator\Api\Data\RetailerTimeSlotInterface;
+use Smile\StoreLocator\Model\ResourceModel\RetailerTimeSlot as TimeSlotResource;
+use Smile\StoreLocator\Api\Data\RetailerTimeSlotInterfaceFactory;
+
+/**
+ * Read Handler for Retailer Opening Hours
+ *
+ * @category Smile
+ * @package  Smile\StoreLocator
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class OpeningHoursReadHandler implements ExtensionInterface
+{
+    /**
+     * @var \Smile\StoreLocator\Model\ResourceModel\RetailerTimeSlot
+     */
+    private $resource;
+
+    /**
+     * @var \Smile\StoreLocator\Api\Data\RetailerTimeSlotInterfaceFactory
+     */
+    private $timeSlotFactory;
+
+    /**
+     * OpeningHoursSaveHandler constructor.
+     *
+     * @param RetailerTimeSlotInterfaceFactory $timeSlotFactory Time Slot Factory
+     * @param TimeSlotResource                 $resource        Resource Model
+     */
+    public function __construct(RetailerTimeSlotInterfaceFactory $timeSlotFactory, TimeSlotResource $resource)
+    {
+        $this->timeSlotFactory = $timeSlotFactory;
+        $this->resource = $resource;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($entity, $arguments = [])
+    {
+        $timeSlots = $this->resource->getTimeSlots($entity->getId(), 'opening_hours');
+        $openingHours = [];
+
+        if (!empty($timeSlots)) {
+            foreach ($timeSlots as $row) {
+                $day = $row[RetailerTimeSlotInterface::DAY_OF_WEEK_FIELD];
+                if (!isset($openingHours[$day])) {
+                    $openingHours[$day] = [];
+                }
+
+                if (null !== $row['start_time'] && null !== $row['end_time']) {
+                    $timeSlotModel = $this->timeSlotFactory->create(
+                        ['data' => ['start_time' => $row['start_time'], 'end_time' => $row['end_time']]]
+                    );
+                    $openingHours[$day][] = $timeSlotModel;
+                }
+            }
+        }
+
+        $entity->getExtensionAttributes()->setOpeningHours($openingHours);
+        $entity->setOpeningHours($openingHours);
+
+        return $entity;
+    }
+}

--- a/Model/Retailer/OpeningHoursSaveHandler.php
+++ b/Model/Retailer/OpeningHoursSaveHandler.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Model\Retailer;
+
+use Magento\Framework\EntityManager\Operation\ExtensionInterface;
+use Smile\StoreLocator\Model\ResourceModel\RetailerTimeSlot as TimeSlotResource;
+
+/**
+ * Save Handler for Retailer Opening Hours
+ *
+ * @category Smile
+ * @package  Smile\StoreLocator
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class OpeningHoursSaveHandler implements ExtensionInterface
+{
+    /**
+     * @var \Smile\StoreLocator\Model\ResourceModel\RetailerTimeSlot
+     */
+    private $resource;
+
+    /**
+     * OpeningHoursSaveHandler constructor.
+     *
+     * @param \Smile\StoreLocator\Model\ResourceModel\RetailerTimeSlot $resource Resource Model
+     */
+    public function __construct(TimeSlotResource $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($entity, $arguments = [])
+    {
+        if ($entity->getOpeningHours()) {
+            $this->resource->saveTimeSlots($entity->getId(), 'opening_hours', $entity->getOpeningHours());
+        }
+
+        return $entity;
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\StoreLocator\Setup;
+
+use Magento\Framework\DB\Ddl\Table;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+
+/**
+ * Upgrade Schema for StoreLocator Module
+ *
+ * @category Smile
+ * @package  Smile\StoreLocator
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * Installs DB schema for a module
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @param SchemaSetupInterface   $setup   Setup
+     * @param ModuleContextInterface $context Context
+     *
+     * @return void
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+        if (version_compare($context->getVersion(), '1.1.0', '<')) {
+            $this->createOpeningHoursTable($setup);
+        }
+        $setup->endSetup();
+    }
+    /**
+     * Create Opening Hours main table
+     *
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup Setup instance
+     */
+    private function createOpeningHoursTable(SchemaSetupInterface $setup)
+    {
+        $table = $setup->getConnection()
+            ->newTable($setup->getTable("smile_retailer_time_slots"))
+            ->addColumn(
+                "retailer_id",
+                Table::TYPE_INTEGER,
+                null,
+                ['unsigned' => true, 'nullable' => false],
+                'Retailer Id'
+            )->addColumn(
+                "attribute_code",
+                Table::TYPE_TEXT,
+                25,
+                ['nullable' => false],
+                'Retailer Id'
+            )->addColumn(
+                "day_of_week",
+                Table::TYPE_SMALLINT,
+                null,
+                ['unsigned' => true, 'nullable' => true, 'default' => null],
+                'Day Of Week'
+            )->addColumn(
+                "date",
+                Table::TYPE_DATE,
+                null,
+                ['nullable' => true, 'default' => null],
+                'Opening Date, if any'
+            )->addColumn(
+                "start_time",
+                Table::TYPE_DATETIME, // Hack : Magento does not support TIME column on its DDL. This column will contain full datetime but work only with hours.
+                null,
+                ['nullable' => true, 'default' => null],
+                'Start Time'
+            )->addColumn(
+                "end_time",
+                Table::TYPE_DATETIME, // Hack : Magento does not support TIME column on its DDL. This column will contain full datetime but work only with hours.
+                null,
+                ['nullable' => true, 'default' => null],
+                'End Time'
+            )->addForeignKey(
+                $setup->getFkName('smile_retailer_time_slots', 'retailer_id', 'smile_seller_entity', 'entity_id'),
+                'retailer_id',
+                $setup->getTable('smile_seller_entity'),
+                'entity_id',
+                \Magento\Framework\DB\Ddl\Table::ACTION_CASCADE
+            )
+            ->setComment('Smile Retailer Opening Hours Table');
+        $setup->getConnection()->createTable($table);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -18,6 +18,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     
     <preference for="Smile\StoreLocator\Api\Data\RetailerAddressInterface" type="Smile\StoreLocator\Model\Data\RetailerAddress" />
+    <preference for="Smile\StoreLocator\Api\Data\RetailerTimeSlotInterface" type="Smile\StoreLocator\Model\Data\RetailerTimeSlot" />
 
     <type name="Magento\Framework\EntityManager\MetadataPool">
         <arguments>
@@ -36,12 +37,15 @@
                 <item name="Smile\Retailer\Api\Data\RetailerInterface" xsi:type="array">
                     <item name="create" xsi:type="array">
                         <item name="create_retailer_address" xsi:type="string">Smile\StoreLocator\Model\Retailer\AddressSaveHandler</item>
+                        <item name="create_retailer_opening_hours" xsi:type="string">Smile\StoreLocator\Model\Retailer\OpeningHoursSaveHandler</item>
                     </item>
                     <item name="update" xsi:type="array">
                         <item name="update_retailer_address" xsi:type="string">Smile\StoreLocator\Model\Retailer\AddressSaveHandler</item>
+                        <item name="update_retailer_opening_hours" xsi:type="string">Smile\StoreLocator\Model\Retailer\OpeningHoursSaveHandler</item>
                     </item>
                     <item name="read" xsi:type="array">
                         <item name="read_retailer_address" xsi:type="string">Smile\StoreLocator\Model\Retailer\AddressReadHandler</item>
+                        <item name="read_retailer_opening_hours" xsi:type="string">Smile\StoreLocator\Model\Retailer\OpeningHoursReadHandler</item>
                     </item>
                 </item>
             </argument>
@@ -52,6 +56,7 @@
         <arguments>
             <argument name="postDataHandlers" xsi:type="array">
                 <item name="addressDataHandler" xsi:type="object">Smile\StoreLocator\Model\Retailer\AddressPostDataHandler</item>
+                <item name="openingHoursDataHandler" xsi:type="object">Smile\StoreLocator\Model\Retailer\OpeningHoursPostDataHandler</item>
             </argument>
         </arguments>
     </type>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -18,5 +18,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Smile\Retailer\Api\Data\RetailerInterface">
         <attribute code="address" type="Smile\Map\Api\Data\GeolocalizedAddressInterface" />
+        <attribute code="opening_hours" type="Smile\StoreLocator\Api\Data\TimeSlotInterface[]" />
     </extension_attributes>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -14,7 +14,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smile_StoreLocator" setup_version="1.0.0">
+    <module name="Smile_StoreLocator" setup_version="1.1.0">
         <sequence>
             <module name="Smile_Retailer"/>
             <module name="Smile_Map"/>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -1,0 +1,23 @@
+"Opening Hours","Opening Hours"
+Home,Home
+"Go to Home Page","Go to Home Page"
+"Our stores","Our stores"
+"We are sorry, an error occured when switching retailer.","We are sorry, an error occured when switching retailer."
+"Retailer url_key ""%1"" already exists.","Retailer url_key ""%1"" already exists."
+"Find a store","Find a store"
+"Store Addrress","Store Addrress"
+Directions,Directions
+"Choose this store","Choose this store"
+"Find a store ...","Find a store ..."
+"My store : %s","My store : %s"
+Address,Address
+Street,Street
+Postcode,Postcode
+City,City
+Country,Country
+Latitude,Latitude
+Longitude,Longitude
+"Find a store :","Find a store :"
+"City, Zipcode, Department, ...","City, Zipcode, Department, ..."
+Search,Search
+Close,Close

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -1,0 +1,23 @@
+"Opening Hours","Horaires d'ouverture"
+Home,Home
+"Go to Home Page","Aller à la page d'accueil"
+"Our stores","Nos magasins"
+"We are sorry, an error occured when switching retailer.","Nous sommes désolés, une erreur s'est produite durant le choix du magasin."
+"Retailer url_key ""%1"" already exists.","La clef d'url ""%1"" existe déjà."
+"Find a store","Trouver un magasin"
+"Store Addrress","Adresse du magasin"
+Directions,Itinéraire
+"Choose this store","Choisir ce magasin"
+"Find a store ...","Trouver un magasin ..."
+"My store : %s","Mon magasin : %s"
+Address,Adresse
+Street,Rue
+Postcode,"Code postal"
+City,Ville
+Country,Pays
+Latitude,Latitude
+Longitude,Longitude
+"Find a store :","Trouver un magasin :"
+"City, Zipcode, Department, ...","Ville, Code postal, Département, ..."
+Search,Rechercher
+Close,Fermer

--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -1,0 +1,23 @@
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+var config = {
+    map: {
+        '*': {
+            estira: 'Smile_StoreLocator/js/elessar/estira',
+            elessar: 'Smile_StoreLocator/js/elessar/elessar',
+            openingHours : 'Smile_StoreLocator/js/opening-hours/rangebar'
+        }
+    }
+};

--- a/view/adminhtml/templates/retailer/openinghours/container.phtml
+++ b/view/adminhtml/templates/retailer/openinghours/container.phtml
@@ -1,0 +1,30 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ *
+ * Opening Hours form element renderer.
+ */
+?>
+
+<?php
+/** @var \Smile\StoreLocator\Block\Adminhtml\Retailer\OpeningHours\Container\Renderer $block */
+
+$element = $block->getElement();
+$fieldId = ($element->getHtmlContainerId()) ? ' id="' . $element->getHtmlContainerId() . '"' : '';
+$fieldClass = "fieldset-{$element->getId()} {$element->getClass()}";
+$fieldClass .= ($element->getRequired()) ? ' required' : '';
+$fieldAttributes = $fieldId . ' class="' . $fieldClass . '" ' . $block->getUiId('form-field', $element->getId());
+?>
+
+<div<?php /* @escapeNotVerified */ echo $fieldAttributes ?>>
+    <?php echo $block->getInputHtml() ?>
+</div>

--- a/view/adminhtml/templates/retailer/openinghours/element.phtml
+++ b/view/adminhtml/templates/retailer/openinghours/element.phtml
@@ -1,0 +1,72 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ *
+ * Opening Hours form element renderer.
+ */
+?>
+
+<?php
+/** @var \Smile\StoreLocator\Block\Adminhtml\Retailer\OpeningHours\Element\Renderer $block */
+
+$element = $block->getElement();
+$fieldId = ($element->getHtmlContainerId()) ? ' id="' . $element->getHtmlContainerId() . '"' : '';
+$fieldClass = "field admin__field field-{$element->getId()} {$element->getClass()}";
+$fieldClass .= ($element->getRequired()) ? ' required' : '';
+$fieldAttributes = $fieldId . ' class="' . $fieldClass . '" ' . $block->getUiId('form-field', $element->getId());
+?>
+
+<div<?php /* @escapeNotVerified */ echo $fieldAttributes ?>>
+    <?php echo $element->getLabelHtml() ?><span class="opening-hours-day" id="<?php echo $this->getHtmlId();?>-label"></span>
+    <?php $inputId = "opening_hours_field_" . $this->getHtmlId() ; ?>
+    <div id ="<?php echo $inputId ?>" class="opening-hours-container">
+        <div class="opening-hours-indicator"></div>
+        <div class="opening-hours-rangebar"></div>
+        <?php echo $block->getInputHtml() ?>
+    </div>
+</div>
+
+<script>
+
+    require(["jquery", "openingHours", "moment"],
+        function($, openingHours, moment) {
+            /**
+             * This component is the main timepicker for opening hours
+             */
+            $("#<?php echo $inputId ?> .opening-hours-rangebar").openingHours({
+                values: $("#<?php echo $this->getHtmlId();?>").val(),
+                summary: $("#<?php echo $this->getHtmlId();?>-label"),
+                updateSummary: true,
+                input : $("#<?php echo $this->getHtmlId();?>")
+            });
+
+            /**
+             * This component is a read-only one, made to display the time indicator
+             */
+            $("#<?php echo $inputId ?> .opening-hours-indicator").openingHours({
+                values: [
+                    [moment().startOf("day").format("LLLL")],
+                    [moment().startOf("day").add(3, "hours").format("LLLL")],
+                    [moment().startOf("day").add(6, "hours").format("LLLL")],
+                    [moment().startOf("day").add(9, "hours").format("LLLL")],
+                    [moment().startOf("day").add(12, "hours").format("LLLL")],
+                    [moment().startOf("day").add(15, "hours").format("LLLL")],
+                    [moment().startOf("day").add(18, "hours").format("LLLL")],
+                    [moment().startOf("day").add(21, "hours").format("LLLL")],
+                    [moment().startOf("day").add(24, "hours").format("LLLL")],
+                ],
+                label: function(a){return JSON.stringify(a[0])},
+                readonly: true
+            });
+        }
+    );
+</script>

--- a/view/adminhtml/ui_component/smile_retailer_form.xml
+++ b/view/adminhtml/ui_component/smile_retailer_form.xml
@@ -136,4 +136,28 @@
             </argument>
         </field>
     </fieldset>
+    <fieldset name="opening_hours">
+        <argument name="data" xsi:type="array">
+            <item name="config" xsi:type="array">
+                <item name="sortOrder" xsi:type="number">200</item>
+                <item name="label" xsi:type="string" translate="true">Opening Hours</item>
+                <item name="collapsible" xsi:type="boolean">true</item>
+            </item>
+        </argument>
+        <container name="opening_hours_config_container">
+            <htmlContent name="opening_hours">
+                <argument name="block" xsi:type="object">Smile\StoreLocator\Block\Adminhtml\Retailer\OpeningHours</argument>
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="sortOrder" xsi:type="number">20</item>
+                        <item name="component" xsi:type="string">Smile_StoreLocator/js/component/retailer/opening-hours</item>
+                        <item name="dataScope" xsi:type="string">opening_hours</item>
+                        <item name="imports" xsi:type="array">
+                            <item name="visible" xsi:type="string">true</item>
+                        </item>
+                    </item>
+                </argument>
+            </htmlContent>
+        </container>
+    </fieldset>
 </form>

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -1,0 +1,91 @@
+// /**
+//  * DISCLAIMER
+//  *
+//  * Do not edit or add to this file if you wish to upgrade this module to newer
+//  * versions in the future.
+//  *
+//  * @category  Smile
+//  * @package   Smile\Retailer
+//  * @author    Romain Ruaud <romain.ruaud@smile.fr>
+//  * @copyright 2016 Smile
+//  * @license   Open Software License ("OSL") v. 3.0
+//  */
+
+/** Import the base elessar module stylesheet **/
+@import (inline) 'elessar/elessar.css';
+
+@timebar-height: 10px;
+
+.opening-hours-container-fieldset {
+    margin-left:70px;
+    margin-top: -30px;
+}
+
+.elessar-range {
+    background:@color-phoenix;
+    height: @timebar-height;
+    overflow: visible;
+}
+.elessar-handle {
+    background-color: @color-gray85;
+    border-radius: 4px;
+    border: 1px solid @color-dark-gray;
+    height: 15px;
+    top: -3px;
+    width: 15px;
+}
+.elessar-rangebar {
+    height: @timebar-height;
+}
+div.opening-hours-container {
+    margin-bottom: 20px;
+    width: 80%;
+    label {
+        margin-top: 20px;
+    }
+}
+div.opening-hours-rangebar {
+    div.elessar-rangebar {
+        background: #FFFFFF;
+        border: 1px solid @color-dark-grayish;
+        margin-left: -1px;
+    }
+}
+div.opening-hours-indicator {
+    margin-top: 40px;
+    span.elessar-barlabel {
+        color: @color-dark-gray;
+        left: -30px;
+        position:relative;
+        top:-35px;
+        &:after {
+            border-left: 1px solid @color-dark-gray;
+            content: " ";
+            display: block;
+            height: @timebar-height;
+            left: 29px;
+            position: relative;
+            top: -5px;
+        }
+    }
+    .elessar-rangebar {
+        height: 0;
+    }
+}
+span.opening-hours-day {
+    color: @color-dark-gray;
+    font-size: 80%;
+}
+
+.admin__control-table td {
+    .admin__control-text._has-datepicker.smile-special-opening-hours-datepicker {
+        width: 15rem;
+    }
+    .opening-hours-wrapper {
+        min-width: 90rem;
+        margin-left: 10%;
+        .opening-hours-container {
+            width: 90%;
+        }
+    }
+}

--- a/view/adminhtml/web/css/source/elessar/elessar.css
+++ b/view/adminhtml/web/css/source/elessar/elessar.css
@@ -1,0 +1,120 @@
+.elessar-handle {
+    display: block;
+    background: black;
+    height: 100%;
+    width: 5px;
+    cursor: ew-resize;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+}
+.elessar-handle:first-child {
+    left: 0;
+}
+.elessar-handle:last-child {
+    right: 0;
+}
+.elessar-vertical .elessar-handle {
+    height: 5px;
+    width: 100%;
+    left: 0;
+    right: 0;
+    top: auto;
+    bottom: auto;
+    cursor: ns-resize;
+}
+.elessar-vertical .elessar-handle:first-child {
+    top: 0;
+}
+.elessar-vertical .elessar-handle:last-child {
+    bottom: 0;
+}
+.elessar-indicator {
+    position: absolute;
+    background: black;
+    border-color: white;
+    border-style: solid;
+    border-width: 0 1px;
+    width: 2px;
+    height: 100%;
+    z-index: 15;
+}
+.elessar-vertical .elessar-indicator {
+    width: 100%;
+    height: 2px;
+}
+.elessar-range {
+    position: absolute;
+    cursor: pointer;
+    cursor: -webkit-grab;
+    cursor: -moz-grab;
+    cursor: grab;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    background: blue;
+    width: 0;
+    z-index: 10;
+}
+.elessar-vertical .elessar-range {
+    width: auto;
+    height: 0;
+}
+.elessar-label {
+    position: absolute;
+    z-index: 5;
+    pointer-events: none;
+    border-left: 1px solid #999;
+    padding-left: 10px;
+}
+.elessar-readonly {
+    opacity: 0.6;
+    cursor: default !important;
+}
+.elessar-phantom {
+    background-color: transparent;
+    background: rgba(0,0,0,0.5);
+    color: white;
+    cursor: pointer !important;
+}
+.elessar-rangebar {
+    position: relative;
+    height: 30px;
+    line-height: 30px;
+    background: #ccc;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+.elessar-delete-confirm {
+    background: red;
+}
+body.elessar-resizing, body.elessar-dragging {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+body.elessar-resizing,
+body.elessar-resizing .bar,
+body.elessar-resizing .handle {
+    cursor: ew-resize !important;
+}
+body.elessar-resizing.elessar-resizing-vertical,
+body.elessar-resizing.elessar-resizing-vertical .bar,
+body.elessar-resizing.elessar-resizing-vertical .handle {
+    cursor: ns-resize !important;
+}
+body.elessar-dragging,
+body.elessar-dragging .bar,
+body.elessar-dragging .handle {
+    cursor: move !important;
+    cursor: -webkit-grabbing !important;
+    cursor: -moz-grabbing !important;
+    cursor: grabbing !important;
+}

--- a/view/adminhtml/web/js/component/retailer/opening-hours.js
+++ b/view/adminhtml/web/js/component/retailer/opening-hours.js
@@ -1,0 +1,115 @@
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+define([
+    'Magento_Ui/js/form/components/html',
+    'jquery',
+    'MutationObserver'
+], function (Component, $) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            value: {},
+            links: {
+                value: '${ $.provider }:${ $.dataScope }'
+            },
+            additionalClasses: "admin__fieldset"
+        },
+
+        /**
+         * Initialize the component
+         */
+        initialize: function ()
+        {
+            this._super();
+            this.initOpeningHoursListener();
+        },
+
+        /**
+         * Init Observation on fields
+         *
+         * @returns {exports}
+         */
+        initObservable: function ()
+        {
+            this._super();
+            this.openingHoursObject = {};
+            this.observe('openingHoursObject value');
+
+            return this;
+        },
+
+        /**
+         * Init Observer on the opening hours fields.
+         */
+        initOpeningHoursListener: function ()
+        {
+            var observer = new MutationObserver(function () {
+                var rootNode = document.getElementById(this.index);
+                if (rootNode !== null) {
+                    this.rootNode = document.getElementById(this.index);
+                    observer.disconnect();
+                    var openingHoursObserver = new MutationObserver(this.updateOpeningHours.bind(this));
+                    var openingHoursObserverConfig = {childList:true, subtree: true, attributes: true};
+                    openingHoursObserver.observe(rootNode, openingHoursObserverConfig);
+                    this.updateOpeningHours();
+                }
+            }.bind(this));
+            var observerConfig = {childList: true, subtree: true};
+            observer.observe(document, observerConfig)
+        },
+
+        /**
+         * Update value of the Opening Hours Object
+         */
+        updateOpeningHours: function ()
+        {
+            var openingHoursObject = {};
+            var hashValues = [];
+
+            $(this.rootNode).find("[name*=" + this.index + "]").each(function () {
+                hashValues.push(this.name + this.value.toString());
+                var currentOpeningHoursObject = openingHoursObject;
+
+                var path = this.name.match(/\[([^[\[\]]+)\]/g)
+                    .map(function (pathItem) { return pathItem.substr(1, pathItem.length-2); });
+
+                while (path.length > 1) {
+                    var currentKey = path.shift();
+
+                    if (currentOpeningHoursObject[currentKey] === undefined) {
+                        currentOpeningHoursObject[currentKey] = {};
+                    }
+
+                    currentOpeningHoursObject = currentOpeningHoursObject[currentKey];
+                }
+
+                currentKey = path.shift();
+                currentOpeningHoursObject[currentKey] = $(this).val();
+            });
+
+            var newHashValue = hashValues.sort().join('');
+
+            if (newHashValue !== this.currentHashValue) {
+                if (this.currentHashValue !== undefined) {
+                    this.bubble('update', true);
+                }
+                this.currentHashValue = newHashValue;
+                this.openingHoursObject(openingHoursObject);
+
+                this.value(openingHoursObject);
+            }
+        }
+    })
+});

--- a/view/adminhtml/web/js/elessar/elessar.js
+++ b/view/adminhtml/web/js/elessar/elessar.js
@@ -1,0 +1,849 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.RangeBar = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+    var Base = require('estira');
+    var $ = (window.jQuery);
+    var requestAnimationFrame = require('./raf');
+
+    var has = Object.prototype.hasOwnProperty;
+
+    var Element = Base.extend({
+        initialize: function(html) {
+
+            this.$el = $(html);
+            this.$data = {};
+            this.$el.data('element', this);
+        },
+        draw: function(css) {
+            var self = this;
+            if(this.drawing) return this.$el;
+            requestAnimationFrame(function() {
+                self.drawing = false;
+                self.$el.css(css);
+            });
+            this.drawing = true;
+            return this.$el;
+        },
+        on: function() {
+            this.$el.on.apply(this.$el, arguments);
+            return this;
+        },
+        one: function() {
+            this.$el.one.apply(this.$el, arguments);
+            return this;
+        },
+        off: function() {
+            this.$el.off.apply(this.$el, arguments);
+            return this;
+        },
+        trigger: function() {
+            this.$el.trigger.apply(this.$el, arguments);
+            return this;
+        },
+        remove: function() {
+            this.$el.remove();
+        },
+        detach: function() {
+            this.$el.detach();
+        },
+        data: function(key, value) {
+            var obj = key;
+            if(typeof key === 'string') {
+                if(typeof value === 'undefined') {
+                    return this.$data[key];
+                }
+                obj = {};
+                obj[key] = value;
+            }
+            $.extend(this.$data, obj);
+            return this;
+        }
+    });
+
+    module.exports = Element;
+
+},{"./raf":6,"estira":10}],2:[function(require,module,exports){
+    var has = Object.prototype.hasOwnProperty;
+
+    module.exports = function getEventProperty(prop, event) {
+        return has.call(event, prop) ? event[prop]
+            : event.originalEvent && event.originalEvent.touches ? event.originalEvent.touches[0][prop]
+            : undefined;
+    };
+
+},{}],3:[function(require,module,exports){
+    var Element = require('./element');
+    var vertical = require('./vertical');
+
+    var Indicator = Element.extend(vertical).extend({
+        initialize: function initialize(options) {
+            initialize.super$.call(this,'<div class="elessar-indicator">');
+            if(options.indicatorClass) this.$el.addClass(options.indicatorClass);
+            if(options.value) this.val(options.value);
+            this.options = options;
+        },
+
+        val: function(pos) {
+            if(pos) {
+                if(this.isVertical()) {
+                    this.draw({top: 100*pos + '%'});
+                } else {
+                    this.draw({left: 100*pos + '%'});
+                }
+                this.value = pos;
+            }
+            return this.value;
+        }
+    });
+
+    module.exports = Indicator;
+
+},{"./element":1,"./vertical":9}],4:[function(require,module,exports){
+    var Element = require('./element.js');
+
+    var Mark = Element.extend({
+        initialize: function initialize(options) {
+            initialize.super$.call(this, '<div class="elessar-label">');
+            this.$el.css(options.perant.edge('start'), (options.value * 100) + '%');
+
+            if(typeof options.label === 'function') {
+                this.$el.text(options.label.call(this, options.perant.normalise(options.value)));
+            } else if(typeof options.label === 'string') {
+                this.$el.text(options.label);
+            } else {
+                this.$el.text(options.perant.normalise(options.value));
+            }
+        }
+    });
+
+    module.exports = Mark;
+
+},{"./element.js":1}],5:[function(require,module,exports){
+    var $ = (window.jQuery);
+    var Range = require('./range');
+    var requestAnimationFrame = require('./raf');
+
+    var Phantom = Range.extend({
+        initialize: function initialize(options) {
+            initialize.super$.call(this, $.extend({
+                readonly: true,
+                label: '+'
+            }, options));
+            this.$el.addClass('elessar-phantom');
+            this.on('mousedown.elessar touchstart.elessar', $.proxy(this.mousedown, this));
+        },
+
+        mousedown: function(ev) {
+            if(ev.which === 1) { // left mouse button
+                var startX = ev.pageX;
+                var newRange = this.options.perant.addRange(this.val());
+                this.remove();
+                this.options.perant.trigger('addrange', [newRange.val(), newRange]);
+                requestAnimationFrame(function() {
+                    newRange.$el.find('.elessar-handle:first-child').trigger(ev.type);
+                });
+            }
+        },
+
+        removePhantom: function() {
+            // NOOP
+        }
+    });
+
+    module.exports = Phantom;
+
+},{"./raf":6,"./range":7}],6:[function(require,module,exports){
+// thanks to http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
+    var lastTime = 0;
+    var vendors = ['webkit', 'moz'], requestAnimationFrame = window.requestAnimationFrame;
+    for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
+        requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
+    }
+
+    if (!requestAnimationFrame) {
+        requestAnimationFrame = function(callback, element) {
+            var currTime = new Date().getTime();
+            var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+            var id = window.setTimeout(function() { callback(currTime + timeToCall); },
+                timeToCall);
+            lastTime = currTime + timeToCall;
+            return id;
+        };
+    }
+
+    module.exports = requestAnimationFrame;
+
+},{}],7:[function(require,module,exports){
+    var $ = (window.jQuery);
+    var Element = require('./element');
+    var getEventProperty = require('./eventprop');
+    var vertical = require('./vertical');
+
+    var Range = Element.extend(vertical).extend({
+        initialize: function initialize(options) {
+            var self = this;
+            initialize.super$.call(this,
+                '<div class="elessar-range"><span class="elessar-barlabel">'
+            );
+            this.options = options;
+            this.perant = options.perant;
+
+            if(this.options.rangeClass) this.$el.addClass(this.options.rangeClass);
+
+            if(!this.readonly()) {
+                this.$el.prepend('<div class="elessar-handle">').append('<div class="elessar-handle">');
+                this.on('mouseenter.elessar touchstart.elessar', $.proxy(this.removePhantom, this));
+                this.on('mousedown.elessar touchstart.elessar', $.proxy(this.mousedown, this));
+                this.on('click', $.proxy(this.click, this));
+            } else {
+                this.$el.addClass('elessar-readonly');
+            }
+            if(typeof this.options.label === 'function') {
+                this.on('changing', function(ev, range) {
+                    self.writeLabel(
+                        self.options.label.call(self, range.map($.proxy(self.perant.normalise, self.perant)))
+                    );
+                });
+            } else {
+                this.writeLabel(this.options.label);
+            }
+
+            this.range = [];
+            this.hasChanged = false;
+
+            if(this.options.value) this.val(this.options.value);
+
+        },
+
+        writeLabel: function(text) {
+            this.$el.find('.elessar-barlabel')[this.options.htmlLabel ? 'html' : 'text'](text);
+        },
+
+        isVertical: function() {
+            return this.perant.options.vertical;
+        },
+
+        removePhantom: function() {
+            this.perant.removePhantom();
+        },
+
+        readonly: function() {
+            if(typeof this.options.readonly === 'function') {
+                return this.options.readonly.call(this.perant, this);
+            }
+            return this.options.readonly;
+        },
+
+        val: function(range, valOpts) {
+
+            if(typeof range === 'undefined') {
+                return this.range;
+            }
+
+            valOpts  = $.extend({},{
+                dontApplyDelta: false,
+                trigger: true
+            }, valOpts || {});
+
+            var next = this.perant.nextRange(this.$el),
+                prev = this.perant.prevRange(this.$el),
+                delta = range[1] - range[0],
+                self = this;
+
+            if(this.options.snap) {
+                range = range.map(snap);
+                delta = snap(delta);
+            }
+            if (next && next.val()[0] <= range[1] && prev && prev.val()[1] >= range[0]) {
+                range[1] = next.val()[0];
+                range[0] = prev.val()[1];
+            }
+            if (next && next.val()[0] < range[1]) {
+                if(!this.perant.options.allowSwap || next.val()[1] >= range[0]) {
+                    range[1] = next.val()[0];
+                    if(!valOpts.dontApplyDelta) range[0] = range[1] - delta;
+                } else {
+                    this.perant.repositionRange(this, range);
+                }
+            }
+            if (prev && prev.val()[1] > range[0]) {
+                if(!this.perant.options.allowSwap || prev.val()[0] <= range[1]) {
+                    range[0] = prev.val()[1];
+                    if(!valOpts.dontApplyDelta) range[1] = range[0] + delta;
+                } else {
+                    this.perant.repositionRange(this, range);
+                }
+            }
+            if (range[1] >= 1) {
+                range[1] = 1;
+                if(!valOpts.dontApplyDelta) range[0] = 1 - delta;
+            }
+            if (range[0] <= 0) {
+                range[0] = 0;
+                if(!valOpts.dontApplyDelta) range[1] = delta;
+            }
+            if(this.perant.options.bound) {
+                var bound = this.perant.options.bound(this);
+                if(bound) {
+                    if(bound.upper && range[1] > this.perant.abnormalise(bound.upper)) {
+                        range[1] = this.perant.abnormalise(bound.upper);
+                        if(!valOpts.dontApplyDelta) range[0] = range[1] - delta;
+                    }
+                    if(bound.lower && range[0] < this.perant.abnormalise(bound.lower)) {
+                        range[0] = this.perant.abnormalise(bound.lower);
+                        if(!valOpts.dontApplyDelta) range[1] = range[0] + delta;
+                    }
+                }
+            }
+
+            if(this.range[0] === range[0] && this.range[1] === range[1]) return this.$el;
+
+            this.range = range;
+
+            if(valOpts.trigger) {
+                this.$el.triggerHandler('changing', [range, this.$el]);
+                this.hasChanged = true;
+            }
+
+            var start = 100*range[0] + '%',
+                size = 100*(range[1] - range[0]) + '%';
+
+            this.draw(
+                this.perant.options.vertical ?
+                {top: start, minHeight: size} :
+                {left: start, minWidth: size}
+            );
+
+            return this;
+
+            function snap(val) { return Math.round(val / self.options.snap) * self.options.snap; }
+            function sign(x)   { return x ? x < 0 ? -1 : 1 : 0; }
+        },
+
+        click: function(ev) {
+            ev.stopPropagation();
+            ev.preventDefault();
+
+            var self = this;
+
+            if(ev.which !== 2 || !this.perant.options.allowDelete) return;
+
+            if(this.deleteConfirm) {
+                this.perant.removeRange(this);
+                clearTimeout(this.deleteTimeout);
+            } else {
+                this.$el.addClass('elessar-delete-confirm');
+                this.deleteConfirm = true;
+
+                this.deleteTimeout = setTimeout(function() {
+                    self.$el.removeClass('elessar-delete-confirm');
+                    self.deleteConfirm = false;
+                }, this.perant.options.deleteTimeout);
+            }
+        },
+
+        mousedown: function(ev) {
+            ev.stopPropagation();
+            ev.preventDefault();
+            this.hasChanged = false;
+            if(ev.which > 1) return;
+
+            if ($(ev.target).is('.elessar-handle:first-child')) {
+                $('body').addClass('elessar-resizing').toggleClass('elessar-resizing-vertical', this.isVertical());
+                $(document).on('mousemove.elessar touchmove.elessar', this.resizeStart(ev));
+            } else if ($(ev.target).is('.elessar-handle:last-child')) {
+                $('body').addClass('elessar-resizing').toggleClass('elessar-resizing-vertical', this.isVertical());
+                $(document).on('mousemove.elessar touchmove.elessar', this.resizeEnd(ev));
+            } else {
+                $('body').addClass('elessar-dragging').toggleClass('elessar-dragging-vertical', this.isVertical());
+                $(document).on('mousemove.elessar touchmove.elessar', this.drag(ev));
+            }
+
+            var self = this;
+
+            $(document).one('mouseup.elessar touchend.elessar', function(ev) {
+                ev.stopPropagation();
+                ev.preventDefault();
+
+                if(self.hasChanged && !self.swapping) self.trigger('change', [self.range, self.$el]);
+                self.swapping = false;
+                $(document).off('mouseup.elessar mousemove.elessar touchend.elessar touchmove.elessar');
+                $('body').removeClass('elessar-resizing elessar-dragging elessar-resizing-vertical elessar-dragging-vertical');
+            });
+        },
+
+        drag: function(origEv) {
+            var self = this,
+                beginStart = this.startProp('offset'),
+                beginPosStart = this.startProp('position'),
+                mousePos = getEventProperty(this.ifVertical('clientY','clientX'), origEv),
+                mouseOffset = mousePos ? mousePos - beginStart : 0,
+                beginSize = this.totalSize(),
+                perant = this.options.perant,
+                perantStart = perant.startProp('offset'),
+                perantSize = perant.totalSize();
+
+            return function(ev) {
+                ev.stopPropagation();
+                ev.preventDefault();
+                var mousePos = getEventProperty(self.ifVertical('clientY','clientX'), ev);
+                if(typeof mousePos !== 'undefined') {
+                    var start = mousePos - perantStart - mouseOffset;
+
+                    if (start >= 0 && start <= perantSize - beginSize) {
+                        var rangeOffset = start / perantSize - self.range[0];
+                        self.val([start / perantSize, self.range[1] + rangeOffset]);
+                    } else {
+                        mouseOffset = mousePos - self.startProp('offset');
+                    }
+                }
+            };
+        },
+        resizeEnd: function(origEv) {
+            var self = this,
+                beginStart = this.startProp('offset'),
+                beginPosStart = this.startProp('position'),
+                mousePos = getEventProperty(this.ifVertical('clientY','clientX'), origEv),
+                mouseOffset = mousePos ? mousePos - beginStart : 0,
+                beginSize = this.totalSize(),
+                perant = this.options.perant,
+                perantStart = perant.startProp('offset'),
+                perantSize = perant.totalSize(),
+                minSize = this.options.minSize * perantSize;
+
+            return function(ev) {
+                var opposite = ev.type === 'touchmove' ? 'touchend' : 'mouseup',
+                    subsequent = ev.type === 'touchmove' ? 'touchstart' : 'mousedown';
+                ev.stopPropagation();
+                ev.preventDefault();
+                var mousePos = getEventProperty(self.ifVertical('clientY','clientX'), ev);
+                var size = mousePos - beginStart;
+
+                if(typeof mousePos !== 'undefined') {
+                    if (size > perantSize - beginPosStart) size = perantSize - beginPosStart;
+                    if (size >= minSize) {
+                        self.val([self.range[0], self.range[0] + size / perantSize], {dontApplyDelta: true});
+                    } else if(size <= 10) {
+                        self.swapping = true;
+                        $(document).trigger(opposite + '.elessar');
+                        self.$el.find('.elessar-handle:first-child').trigger(subsequent + '.elessar');
+                    }
+                }
+            };
+        },
+
+        resizeStart: function(origEv) {
+            var self = this,
+                beginStart = this.startProp('offset'),
+                beginPosStart = this.startProp('position'),
+                mousePos = getEventProperty(this.ifVertical('clientY','clientX'), origEv),
+                mouseOffset = mousePos ? mousePos - beginStart : 0,
+                beginSize = this.totalSize(),
+                perant = this.options.perant,
+                perantStart = perant.startProp('offset'),
+                perantSize = perant.totalSize(),
+                minSize = this.options.minSize * perantSize;
+
+            return function(ev) {
+                var opposite = ev.type === 'touchmove' ? 'touchend' : 'mouseup',
+                    subsequent = ev.type === 'touchmove' ? 'touchstart' : 'mousedown';
+
+                ev.stopPropagation();
+                ev.preventDefault();
+                var mousePos = getEventProperty(self.ifVertical('clientY','clientX'), ev);
+                var start = mousePos - perantStart - mouseOffset;
+                var size = beginPosStart + beginSize - start;
+
+                if(typeof mousePos !== 'undefined') {
+                    if (start < 0) {
+                        start = 0;
+                        size = beginPosStart + beginSize;
+                    }
+                    if (size >= minSize) {
+                        self.val([start / perantSize, self.range[1]], {dontApplyDelta: true});
+                    } else if(size <= 10) {
+                        self.swapping = true;
+                        $(document).trigger(opposite + '.elessar');
+                        self.$el.find('.elessar-handle:last-child').trigger(subsequent + '.elessar');
+                    }
+                }
+            };
+        }
+    });
+
+    module.exports = Range;
+
+
+},{"./element":1,"./eventprop":2,"./vertical":9}],8:[function(require,module,exports){
+    var Element = require('./element');
+    var Range = require('./range');
+    var Phantom = require('./phantom');
+    var Indicator = require('./indicator');
+    var getEventProperty = require('./eventprop');
+    var vertical = require('./vertical');
+    var $ = (window.jQuery);
+    var Mark = require('./mark.js');
+
+    var RangeBar = Element.extend(vertical).extend({
+        initialize: function initialize(options) {
+            options = options || {};
+            initialize.super$.call(this, '<div class="elessar-rangebar">');
+            this.options = $.extend({}, RangeBar.defaults, options);
+            this.options.min = this.options.valueParse(this.options.min);
+            this.options.max = this.options.valueParse(this.options.max);
+            if(this.options.barClass) this.$el.addClass(this.options.barClass);
+            if(this.options.vertical) this.$el.addClass('elessar-vertical');
+
+            this.ranges = [];
+            this.on('mousemove.elessar touchmove.elessar', $.proxy(this.mousemove, this));
+            this.on('mouseleave.elessar touchleave.elessar', $.proxy(this.removePhantom, this));
+
+            if(options.values) this.setVal(options.values);
+
+            if(options.bgLabels) {
+                options.bgMark = { count: options.bgLabels };
+            }
+
+            if(options.bgMark) {
+                this.$markContainer = $('<div class="elessar-labels">').appendTo(this.$el);
+                if(options.bgMark.count) {
+                    for(var i = 0; i < options.bgMark.count; ++i) {
+                        this.$markContainer.append((new Mark({
+                            label: options.bgMark.label,
+                            value: i / options.bgMark.count,
+                            perant: this
+                        })).$el);
+                    }
+                } else if(options.bgMark.interval) {
+                    for(var i = this.abnormalise(this.options.min); i < this.abnormalise(this.options.max); i += this.abnormalise(options.bgMark.interval)) {
+                        this.$markContainer.append((new Mark({
+                            label: options.bgMark.label,
+                            value: i,
+                            perant: this
+                        })).$el);
+                    }
+                }
+            }
+
+            var self = this;
+
+            if(options.indicator) {
+                var indicator = this.indicator = new Indicator({
+                    perant: this,
+                    vertical: this.options.vertical,
+                    indicatorClass: options.indicatorClass
+                });
+                indicator.val(this.abnormalise(options.indicator(this, indicator, function() {
+                    indicator.val(self.abnormalise(options.indicator(self, indicator)));
+                })));
+                this.$el.append(indicator.$el);
+            }
+        },
+
+        normaliseRaw: function (value) {
+            return this.options.min + value * (this.options.max - this.options.min);
+        },
+
+        normalise: function (value) {
+            return this.options.valueFormat(this.normaliseRaw(value));
+        },
+
+        abnormaliseRaw: function (value) {
+            return (value - this.options.min)/(this.options.max - this.options.min);
+        },
+
+        abnormalise: function (value) {
+            return this.abnormaliseRaw(this.options.valueParse(value));
+        },
+
+        findGap: function(range) {
+            var newIndex = 0;
+            this.ranges.forEach(function($r, i) {
+                if($r.val()[0] < range[0] && $r.val()[1] < range[1]) newIndex = i + 1;
+            });
+
+            return newIndex;
+        },
+
+        insertRangeIndex: function(range, index, avoidList) {
+            if(!avoidList) this.ranges.splice(index, 0, range);
+
+            if(this.ranges[index - 1]) {
+                this.ranges[index - 1].$el.after(range.$el);
+            } else {
+                this.$el.prepend(range.$el);
+            }
+        },
+
+        addRange: function(range, data) {
+            var $range = Range({
+                perant: this,
+                snap: this.options.snap ? this.abnormaliseRaw(this.options.snap + this.options.min) : null,
+                label: this.options.label,
+                rangeClass: this.options.rangeClass,
+                minSize: this.options.minSize ? this.abnormaliseRaw(this.options.minSize + this.options.min) : null,
+                readonly: this.options.readonly,
+                htmlLabel: this.options.htmlLabel
+            });
+
+            if (this.options.data) {
+                $range.data(this.options.data.call($range, this));
+            }
+
+            if (data) {
+                $range.data(data);
+            }
+
+            this.insertRangeIndex($range, this.findGap(range));
+            $range.val(range);
+
+            var self = this;
+
+            $range.on('changing', function(ev, nrange, changed) {
+                ev.stopPropagation();
+                self.trigger('changing', [self.val(), changed]);
+            }).on('change', function(ev, nrange, changed) {
+                ev.stopPropagation();
+                self.trigger('change', [self.val(), changed]);
+            });
+            return $range;
+        },
+
+        prevRange: function(range) {
+            var idx = range.index();
+            if(idx >= 0) return this.ranges[idx - 1];
+        },
+
+        nextRange: function(range) {
+            var idx = range.index();
+            if(idx >= 0) return this.ranges[range instanceof Phantom ? idx : idx + 1];
+        },
+
+        setVal: function(ranges) {
+            if (this.ranges.length > ranges.length) {
+                for (var i = ranges.length-1, l = this.ranges.length-1; i < l; --l) {
+                    this.removeRange(l);
+                }
+                this.ranges.length = ranges.length;
+            }
+
+            var self = this;
+
+            ranges.forEach(function(range, i) {
+                if(self.ranges[i]) {
+                    self.ranges[i].val(range.map($.proxy(self.abnormalise, self)));
+                } else {
+                    self.addRange(range.map($.proxy(self.abnormalise, self)));
+                }
+            });
+
+            return this;
+        },
+
+        val: function(ranges) {
+            var self = this;
+            if(typeof ranges === 'undefined') {
+                return this.ranges.map(function(range) {
+                    return range.val().map($.proxy(self.normalise, self));
+                });
+            }
+
+            if(!this.readonly()) this.setVal(ranges);
+            return this;
+        },
+
+        removePhantom: function() {
+            if(this.phantom) {
+                this.phantom.remove();
+                this.phantom = null;
+            }
+        },
+
+        removeRange: function(i, noTrigger, preserveEvents) {
+            if(i instanceof Range) {
+                i = this.ranges.indexOf(i);
+            }
+            this.ranges.splice(i,1)[0][preserveEvents ? 'detach' : 'remove']();
+            if(!noTrigger) {
+                this.trigger('change', [this.val()]);
+            }
+        },
+
+        repositionRange: function(range, val) {
+            this.removeRange(range, true, true);
+            this.insertRangeIndex(range, this.findGap(val));
+        },
+
+        calcGap: function(index) {
+            var start = this.ranges[index - 1] ? this.ranges[index - 1].val()[1] : 0;
+            var end = this.ranges[index] ? this.ranges[index].val()[0] : 1;
+            return this.normaliseRaw(end) - this.normaliseRaw(start);
+        },
+
+        readonly: function() {
+            if(typeof this.options.readonly === 'function') {
+                return this.options.readonly.call(this);
+            }
+            return this.options.readonly;
+        },
+
+        mousemove: function(ev) {
+            var w = this.options.minSize ? this.abnormaliseRaw(this.options.minSize + this.options.min) : 0.05;
+            var pageStart = getEventProperty(this.ifVertical('pageY','pageX'), ev);
+            var val = (pageStart - this.startProp('offset'))/this.totalSize() - w/2;
+
+            var direct = ev.target === ev.currentTarget;
+            var phantom = $(ev.target).is('.elessar-phantom');
+
+            if((direct || phantom) && this.ranges.length < this.options.maxRanges && !$('body').is('.elessar-dragging, .elessar-resizing') && !this.readonly()) {
+                if(!this.phantom) this.phantom = Phantom({
+                    perant: this,
+                    snap: this.options.snap ? this.abnormaliseRaw(this.options.snap + this.options.min) : null,
+                    label: "+",
+                    minSize: this.options.minSize ? this.abnormaliseRaw(this.options.minSize + this.options.min) : null,
+                    rangeClass: this.options.rangeClass
+                });
+                var idx = this.findGap([val,val + w]);
+                var self = this;
+                this.one('addrange', function(ev, val, range) {
+                    range.one('mouseup', function() {
+                        self.trigger('change', [self.val(), range]);
+                    });
+                });
+
+                if(!this.options.minSize || this.calcGap(idx) >= this.options.minSize) {
+                    this.insertRangeIndex(this.phantom, idx, true);
+                    this.phantom.val([val,val + w], {trigger: false});
+                }
+            }
+        }
+    });
+
+    RangeBar.defaults = {
+        min: 0,
+        max: 100,
+        valueFormat: function (a) {return a;},
+        valueParse: function (a) {return a;},
+        maxRanges: Infinity,
+        readonly: false,
+        bgLabels: 0,
+        deleteTimeout: 5000,
+        allowDelete: false,
+        vertical: false,
+        htmlLabel: false,
+        allowSwap: true
+    };
+
+    module.exports = RangeBar;
+
+},{"./element":1,"./eventprop":2,"./indicator":3,"./mark.js":4,"./phantom":5,"./range":7,"./vertical":9}],9:[function(require,module,exports){
+    module.exports = {
+        isVertical: function() {
+            return this.options.vertical;
+        },
+
+        ifVertical: function(v, h) {
+            return this.isVertical() ? v : h;
+        },
+        edge: function(which) {
+            if(which === 'start') {
+                return this.ifVertical('top', 'left');
+            } else if(which === 'end') {
+                return this.ifVertical('bottom', 'right');
+            }
+            throw new TypeError('What kind of an edge is ' + which);
+        },
+        totalSize: function() {
+            return this.$el[this.ifVertical('height','width')]();
+        },
+        edgeProp: function(edge, prop) {
+            var o = this.$el[prop]();
+            return o[this.edge(edge)];
+        },
+        startProp: function(prop) {
+            return this.edgeProp('start', prop);
+        },
+        endProp: function(prop) {
+            return this.edgeProp('end', prop);
+        }
+    };
+
+},{}],10:[function(require,module,exports){
+    (function(){
+        (function(definition){
+            switch (false) {
+                case !(typeof define === 'function' && define.amd != null):
+                    return define([], definition);
+                case typeof exports !== 'object':
+                    return module.exports = definition();
+                default:
+                    return this.Base = definition();
+            }
+        })(function(){
+            var Base;
+            return Base = (function(){
+                Base.displayName = 'Base';
+                var attach, prototype = Base.prototype, constructor = Base;
+                attach = function(obj, name, prop, super$, superclass$){
+                    return obj[name] = typeof prop === 'function' ? import$(function(){
+                        var this$ = this;
+                        prop.superclass$ = superclass$;
+                        prop.super$ = function(){
+                            return super$.apply(this$, arguments);
+                        };
+                        return prop.apply(this, arguments);
+                    }, prop) : prop;
+                };
+                Base.extend = function(displayName, proto){
+                    proto == null && (proto = displayName);
+                    return (function(superclass){
+                        var name, ref$, prop, prototype = extend$(import$(constructor, superclass), superclass).prototype;
+                        import$(constructor, Base);
+                        if (typeof displayName === 'string') {
+                            constructor.displayName = displayName;
+                        }
+                        function constructor(){
+                            var this$ = this instanceof ctor$ ? this : new ctor$;
+                            this$.initialize.apply(this$, arguments);
+                            return this$;
+                        } function ctor$(){} ctor$.prototype = prototype;
+                        prototype.initialize = function(){
+                            if (superclass.prototype.initialize != null) {
+                                return superclass.prototype.initialize.apply(this, arguments);
+                            } else {
+                                return superclass.apply(this, arguments);
+                            }
+                        };
+                        for (name in ref$ = proto) {
+                            prop = ref$[name];
+                            attach(prototype, name, prop, prototype[name], superclass);
+                        }
+                        return constructor;
+                    }(this));
+                };
+                Base.meta = function(meta){
+                    var name, prop;
+                    for (name in meta) {
+                        prop = meta[name];
+                        attach(this, name, prop, this[name], this);
+                    }
+                    return this;
+                };
+                prototype.initialize = function(){};
+                function Base(){}
+                return Base;
+            }());
+        });
+        function import$(obj, src){
+            var own = {}.hasOwnProperty;
+            for (var key in src) if (own.call(src, key)) obj[key] = src[key];
+            return obj;
+        }
+        function extend$(sub, sup){
+            function fun(){} fun.prototype = (sub.superclass = sup).prototype;
+            (sub.prototype = new fun).constructor = sub;
+            if (typeof sup.extended == 'function') sup.extended(sub);
+            return sub;
+        }
+    }).call(this);
+
+},{}]},{},[8])(8)
+});

--- a/view/adminhtml/web/js/elessar/estira.js
+++ b/view/adminhtml/web/js/elessar/estira.js
@@ -1,0 +1,77 @@
+(function(){
+    (function(definition){
+        switch (false) {
+            case !(typeof define === 'function' && define.amd != null):
+                return define([], definition);
+            case typeof exports !== 'object':
+                return module.exports = definition();
+            default:
+                return this.Base = definition();
+        }
+    })(function(){
+        var Base;
+        return Base = (function(){
+            Base.displayName = 'Base';
+            var attach, prototype = Base.prototype, constructor = Base;
+            attach = function(obj, name, prop, super$, superclass$){
+                return obj[name] = typeof prop === 'function' ? import$(function(){
+                    var this$ = this;
+                    prop.superclass$ = superclass$;
+                    prop.super$ = function(){
+                        return super$.apply(this$, arguments);
+                    };
+                    return prop.apply(this, arguments);
+                }, prop) : prop;
+            };
+            Base.extend = function(displayName, proto){
+                proto == null && (proto = displayName);
+                return (function(superclass){
+                    var name, ref$, prop, prototype = extend$(import$(constructor, superclass), superclass).prototype;
+                    import$(constructor, Base);
+                    if (typeof displayName === 'string') {
+                        constructor.displayName = displayName;
+                    }
+                    function constructor(){
+                        var this$ = this instanceof ctor$ ? this : new ctor$;
+                        this$.initialize.apply(this$, arguments);
+                        return this$;
+                    } function ctor$(){} ctor$.prototype = prototype;
+                    prototype.initialize = function(){
+                        if (superclass.prototype.initialize != null) {
+                            return superclass.prototype.initialize.apply(this, arguments);
+                        } else {
+                            return superclass.apply(this, arguments);
+                        }
+                    };
+                    for (name in ref$ = proto) {
+                        prop = ref$[name];
+                        attach(prototype, name, prop, prototype[name], superclass);
+                    }
+                    return constructor;
+                }(this));
+            };
+            Base.meta = function(meta){
+                var name, prop;
+                for (name in meta) {
+                    prop = meta[name];
+                    attach(this, name, prop, this[name], this);
+                }
+                return this;
+            };
+            prototype.initialize = function(){};
+            function Base(){}
+            return Base;
+        }());
+    });
+    function import$(obj, src){
+        var own = {}.hasOwnProperty;
+        for (var key in src) if (own.call(src, key)) obj[key] = src[key];
+        return obj;
+    }
+    function extend$(sub, sup){
+        function fun(){} fun.prototype = (sub.superclass = sup).prototype;
+        (sub.prototype = new fun).constructor = sub;
+        if (typeof sup.extended == 'function') sup.extended(sub);
+        return sub;
+    }
+}).call(this);

--- a/view/adminhtml/web/js/opening-hours/rangebar.js
+++ b/view/adminhtml/web/js/opening-hours/rangebar.js
@@ -1,0 +1,203 @@
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this file to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\StoreLocator
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+/*jshint browser:true jquery:true*/
+define([
+    'jquery',
+    'underscore',
+    'elessar',
+    'moment',
+    'mage/translate'
+], function ($, _, RangeBar, moment, translator) {
+    'use strict';
+
+    $.widget('smile.openingHours', {
+        options: {
+            snap: 1000 * 60 * 15,
+            minSize: 0, //(1000 * 60 * 60) / 4,
+            allowDelete: true,
+            htmlLabel: true,
+            min: moment().startOf("day").format("LLLL"),
+            max: moment().endOf("day").format("LLLL"),
+            valueFormat: function(ts) {
+                return moment(ts).format("HH:mm");
+            },
+            valueParse: function(date) {
+                return moment(date).valueOf();
+            },
+            indicator:false,
+            updateSummary:false,
+            summary:null,
+            deleteConfirm:true
+        },
+
+        /**
+         * Initialize the Widget, internal constructor
+         *
+         * @private
+         */
+        _create: function ()
+        {
+            if (this.options.values) {
+                if (typeof this.options.values === "string") {
+                    this.options.values = JSON.parse(this.options.values);
+                }
+            }
+
+            this.initRangeBarElement().initSummary().initInput().bindRangesDelete();
+
+            this.rangeBar.on("change", this.bindRangesDelete.bind(this));
+
+            this.element.prepend(this.rangeBar);
+        },
+
+        /**
+         * Init Range Bar Element
+         *
+         * @private
+         *
+         * @returns {smile.openingHours}
+         */
+        initRangeBarElement: function()
+        {
+            var rangeBarWidget = new RangeBar(this.options);
+
+            this.rangeBarWidget = rangeBarWidget;
+            this.rangeBar = rangeBarWidget.$el;
+
+            if (this.options.onChange) {
+                this.rangeBar.on("change", this.options.onChange);
+            }
+
+            if (this.options.onChanging) {
+                this.rangeBar.on("changing", this.options.onChanging);
+            }
+
+            return this;
+        },
+
+        /**
+         * Init Summary Element if any
+         *
+         * @private
+         *
+         * @returns {smile.openingHours}
+         */
+        initSummary: function()
+        {
+            if (this.options.updateSummary === true && this.options.summary !== null) {
+                this.summary = $(this.options.summary);
+                this.prepareSummaryListening();
+                if (this.options.values.length) {
+                    this.updateSummary(this.rangeBarWidget.val());
+                }
+            }
+
+            return this;
+        },
+
+        /**
+         * Init Input element if any
+         *
+         * @private
+         *
+         * @returns {smile.openingHours}
+         */
+        initInput: function()
+        {
+            if (this.options.input !== null) {
+                this.input = $(this.options.input);
+                this.prepareInputBinding();
+                if (this.options.values.length) {
+                    this.input.val(JSON.stringify(this.rangeBarWidget.val(),null,2))
+                }
+            }
+
+            return this;
+        },
+
+        /**
+         * Bind data to the input field when the slider is changing.
+         */
+        prepareInputBinding: function()
+        {
+            if (this.input) {
+                var callback = function(ev, ranges) {this.input.val(JSON.stringify(ranges,null,2))}.bind(this);
+
+                this.rangeBarEvent("change", callback);
+                this.rangeBarEvent("changing", callback);
+            }
+        },
+
+        /**
+         * Bind data to the summary field (if any, and if summarize is activated) when the slider is changing.
+         */
+        prepareSummaryListening: function()
+        {
+            var callback = function(ev, ranges) { this.updateSummary(ranges) }.bind(this);
+
+            this.rangeBarEvent("change", callback);
+            this.rangeBarEvent("changing", callback);
+        },
+
+        /**
+         * Bind Delete event handler on double click for ranges
+         */
+        bindRangesDelete: function()
+        {
+            this.rangeBarWidget.ranges.forEach(function(range) {
+                if (!range.$el.hasClass("delete-bound")) {
+                    range.$el.one('dblclick', function (ev) {
+                        ev.preventDefault();
+                        ev.stopPropagation();
+                        this.rangeBarWidget.removeRange(range)
+                    }.bind(this));
+                    range.$el.addClass("delete-bound");
+                }
+            }.bind(this));
+        },
+
+        /**
+         * Update summary field according to content of the slider
+         *
+         * @param ranges The ranges to display in summary field
+         */
+        updateSummary: function (ranges)
+        {
+            var rangeLabels = [];
+            ranges.forEach(function (rangeItem) {
+                var subRangeLabels = [];
+                rangeItem.forEach(function (dateItem) {
+                    subRangeLabels.push(dateItem);
+                });
+                rangeLabels.push(subRangeLabels.join(" - "));
+            });
+            var label = rangeLabels.join(", ");
+            this.summary.text(label)
+        },
+
+        /**
+         * Bind events on rangeBar
+         *
+         * @param eventName The event name
+         * @param callback A function callback
+         */
+        rangeBarEvent: function (eventName, callback)
+        {
+            this.rangeBar.on(eventName, callback);
+        }
+
+    });
+
+    return $.smile.openingHours;
+});


### PR DESCRIPTION
Restore the old adminhtml form.

Using three classes to implement the CRUD :  

- Smile\StoreLocator\Model\Retailer\OpeningHoursPostDataHandler
- Smile\StoreLocator\Model\Retailer\OpeningHoursReadHandler
- Smile\StoreLocator\Model\Retailer\OpeningHoursSaveHandler

There is also a class modelizing a "time slot" : 

- Smile\StoreLocator\Model\Data\RetailerTimeSlot

Here is sample of data of the getOpeningHours method return for a retailer open only on sunday (the day 0) : 

```
Array
(
    [0] => Array
        (
            [0] => Smile\StoreLocator\Model\Data\RetailerTimeSlot Object
                (
                    [_data:protected] => Array
                        (
                            [start_time] => 02:30
                            [end_time] => 06:00
                        )

                )

            [1] => Smile\StoreLocator\Model\Data\RetailerTimeSlot Object
                (
                    [_data:protected] => Array
                        (
                            [start_time] => 09:00
                            [end_time] => 12:00
                        )

                )

        )

)
```