### PR TITLE
Fixed error in php7.2 error incompatible

### DIFF
--- a/Model/RetailerAddress/Source/Country.php
+++ b/Model/RetailerAddress/Source/Country.php
@@ -54,7 +54,7 @@ class Country extends Table
     /**
      * {@inheritdoc}
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if ($this->_options === null) {
             $this->_options = $this->countriesFactory->create()


### PR DESCRIPTION
Fixed error incompatible in 7.2
"Fatal error: Declaration of Smile\StoreLocator\Model\RetailerAddress\Source\Country::getAllOptions() must be compatible with Magento\Eav\Model\Entity\Attribute\Source\Table::getAllOptions($withEmpty = true, $defaultValues = false) in /vendor/smile/module-store-locator/Model/RetailerAddress/Source/Country.php on line 67"