### PR TITLE
Prevent excessive locale fetches from redis

### DIFF
--- a/Model/ResourceModel/RetailerTimeSlot.php
+++ b/Model/ResourceModel/RetailerTimeSlot.php
@@ -34,6 +34,11 @@ class RetailerTimeSlot extends AbstractDb
     private $localeResolver;
 
     /**
+     * @var null
+     */
+    private $locale;
+
+    /**
      * RetailerTimeSlot constructor.
      *
      * @param Context     $context        Context
@@ -43,6 +48,7 @@ class RetailerTimeSlot extends AbstractDb
     public function __construct(Context $context, Resolver $localeResolver, $connectionName = null)
     {
         $this->localeResolver = $localeResolver;
+        $this->locale = $this->localeResolver->getLocale();
         parent::__construct($context, $connectionName);
     }
 
@@ -217,9 +223,8 @@ class RetailerTimeSlot extends AbstractDb
      */
     private function dateToHour($date)
     {
-        $date = new Zend_Date($date, DateTime::DATETIME_INTERNAL_FORMAT);
-        $date->setLocale($this->localeResolver->getLocale());
+        setlocale(LC_TIME, $this->locale);
 
-        return $date->toString(Zend_Date::TIME_SHORT);
+        return $date = strftime('%H:%M', strtotime($date));
     }
 }

--- a/Model/ResourceModel/RetailerTimeSlot.php
+++ b/Model/ResourceModel/RetailerTimeSlot.php
@@ -223,8 +223,12 @@ class RetailerTimeSlot extends AbstractDb
      */
     private function dateToHour($date)
     {
-        setlocale(LC_TIME, $this->locale);
+        $formatter = new \IntlDateFormatter(
+            $this->locale,
+            \IntlDateFormatter::NONE,
+            \IntlDateFormatter::SHORT
+        );
 
-        return $date = strftime('%H:%M', strtotime($date));
+        return $formatter->format(\DateTime::createFromFormat('Y-m-d H:i:s', $date));
     }
 }


### PR DESCRIPTION
I saw many locale lookups (~**3500** hget calls) on a product/view page with
`$this->getCurrentMode() === Navigation::DRIVE_MODE`
```
1560323938.063142 [2 unix:/tmp/redis.sock] "hget" "zc:k:2b3_Zend_LocaleL_en_GB_day_" "d"
1560323938.245287 [2 unix:/tmp/redis.sock] "hget" "zc:k:2b3_Zend_LocaleL_en_GB_month_" "d"
1560323938.425919 [2 unix:/tmp/redis.sock] "hget" "zc:k:2b3_Zend_LocaleL_en_GB_month_gregorian_format_abbreviated" "d"
1560323938.602275 [2 unix:/tmp/redis.sock] "hget" "zc:k:2b3_Zend_LocaleC_en_NZ_time_short" "d"
1560324031.566040 [2 unix:/tmp/redis.sock] "hget" "zc:k:2b3_Zend_LocaleC_en_NZ_am_" "d"
```

This PR tries to fix that by setting the locale in memory, then using `strftime` to get the date format  

```
cat /tmp/hget_before.txt |wc -l
    3674

cat /tmp/hget_after_code_change.txt |wc -l
     528
```