### PR TITLE
[Fix] Add condition to avoid error during Retailer create

### DIFF
--- a/Model/Retailer/OpeningHoursPostDataHandler.php
+++ b/Model/Retailer/OpeningHoursPostDataHandler.php
@@ -98,7 +98,7 @@ class OpeningHoursPostDataHandler implements \Smile\Retailer\Model\Retailer\Post
             }
 
             // If not a single opening hour is saved, we delete existing entry for current retailer
-            if (empty($openingHours)) {
+            if (empty($openingHours) && isset($data['entity_id']) && !empty($data['entity_id'])) {
                 $this->retailerTimeSlot->deleteByRetailerId($data['entity_id']);
             }
 


### PR DESCRIPTION
Related to : https://github.com/Smile-SA/magento2-module-store-locator/pull/55#issuecomment-515945574

Test entity_id before trying to delete opening hour slot, as during creation entity_id is not set