### PR TITLE
Bug fix for standalone use

### DIFF
--- a/Block/Search.php
+++ b/Block/Search.php
@@ -19,7 +19,6 @@ use Smile\Map\Api\MapInterface;
 use Smile\Map\Model\AddressFormatter;
 use Smile\Retailer\Api\Data\RetailerInterface;
 
-use Smile\RetailerPromotion\Api\PromotionRepositoryInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 
 use Smile\RetailerService\Api\ServiceRepositoryInterface;
@@ -78,8 +77,7 @@ class Search extends \Magento\Framework\View\Element\Template implements Identit
     private $serializer;
 
     private $searchCriteriaBuilder;
-
-    private $serviceRepositoryInterface;
+    
     /**
      * Constructor.
      *
@@ -102,9 +100,7 @@ class Search extends \Magento\Framework\View\Element\Template implements Identit
         \Smile\StoreLocator\Helper\Schedule $scheduleHelper,
         \Smile\StoreLocator\Model\Retailer\ScheduleManagement $scheduleManagement,
         SerializerInterface $serializer,
-        PromotionRepositoryInterface $promotionRepository,
         SearchCriteriaBuilder $searchCriteriaBuilder,
-        ServiceRepositoryInterface $serviceRepositoryInterface,
         $data = []
     ) {
         parent::__construct($context, $data);
@@ -117,7 +113,6 @@ class Search extends \Magento\Framework\View\Element\Template implements Identit
         $this->cacheInterface            = $context->getCache();
         $this->serializer = $serializer;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
-        $this->serviceRepositoryInterface = $serviceRepositoryInterface;
         $this->addData(
             [
                 'cache_lifetime' => false,

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "magento/framework": "*",
         "magento/module-store": "*",
         "magento/module-contact": "*",
-        "smile/module-map": "^1.1.0",
+        "smile/module-map": "^2.0.0",
         "smile/module-retailer": "^1.2.0",
         "willdurand/geocoder": "^3.3"
     },


### PR DESCRIPTION
In `smile/module-map`, the `map.js` do not declare `closeDetails` function required by 
`magento2-module-store-locator/view/frontend/web/template/retailer/search.html`line 74

In addition, the module smile-SA/magento2-module-seller is not compatible in version 1.2.5.
`Smile\Seller\Api\Data\ SellerInterface` do not declare MEDIA_PATH