### PR TITLE
Add data- attributes for opening-hours dropdown widget on store details

### DIFF
--- a/view/frontend/web/template/retailer/opening-hours.html
+++ b/view/frontend/web/template/retailer/opening-hours.html
@@ -5,7 +5,8 @@
             <a href="#" onClick="return false;"></a>
         </div>
     </div>
-    <div class="block catalog-product-stores-availability-content" data-role="">
+    <div data-block="opening-hours-dropdown"></div>
+    <div class="block catalog-product-stores-availability-content" data-role="openingHoursDropDown">
         <div class="opening-hours">
             <table class="opening-hours-table">
                 <tbody data-bind="{foreach: openingHoursList}" data-role="opening-hours-table">


### PR DESCRIPTION
Hi,

In checkout, when choosing a pick up store and checking out opening hours in store details, dropdown widget is not properly working if we click on .showopeninghours element (shopStatus)

I'd like to know if you reproduce, because i extended this part and made a few modifications.
In my environment, `data-role="openingHoursDropDown"` and `data-block="opening-hours-dropdown" ` are missing in final html because they are in open-hours-view.html template, which is only displayed on **smile_store_locator-store-search** page.

These attributes are used in initDropdown() and i only propose to put them in opening-hours.html template to restore dropdown functionnality.

Regards 