### PR TITLE
Make shop status strings translatable in map-mixin and schedule.js

### DIFF
--- a/view/frontend/web/js/map-mixin.js
+++ b/view/frontend/web/js/map-mixin.js
@@ -188,14 +188,14 @@ define([
          * @returns {string}
          */
         prepareShopStatus: function (markerData) {
-            if(!markerData.nerby) {
+            if (!markerData.nerby) {
                 var schedule = markerData.getSchedule();
             } else {
                 var schedule = markerData.schedule;
             }
             var isOpen = schedule.isOpenToday();
             var statusClass;
-            if(!isOpen) {
+            if (!isOpen) {
                 isOpen = 'Closed';
                 statusClass = 'close-shop';
             } else {
@@ -203,17 +203,29 @@ define([
                 statusClass = 'open-shop';
             }
             var time = schedule.getTodayCloseTime(isOpen);
-            if(time === 'closeNow') {
+            if (time === 'closeNow') {
                 isOpen = 'closeNow';
                 statusClass = 'close-shop';
                 time = schedule.getTodayCloseTime(isOpen);
                 isOpen = 'Closed';
             }
+            var htmlTime = '';
+            if (time) {
+                htmlTime = $.mage.__(' - today until ') + '<span>' + time + '</span>';
+            }
+
             var openDay = schedule.getDayWhenStoreOpen();
             if (!openDay) {
                 openDay = '';
             }
-            var html = '<span class="'+ statusClass +'">'+ isOpen +'</span> - today until <span>'+ time +'</span><span>'+ openDay +'</span>';
+            // add translation to 'Open' term used in getTodayCloseTime()
+            if (isOpen === 'Open') {
+                isOpen =  $.mage.__('Open');
+            } else if (isOpen === 'Closed') {
+                isOpen =  $.mage.__('Closed');
+            }
+            var html = '<span class="' + statusClass + '">' + isOpen +  '</span>' + htmlTime + '<span>' + openDay + '</span>';
+
             return html;
         },
 

--- a/view/frontend/web/js/model/store/schedule.js
+++ b/view/frontend/web/js/model/store/schedule.js
@@ -204,7 +204,7 @@ define(['jquery', 'uiClass', 'moment', 'ko', 'mage/translate', 'mage/dropdown'],
                 i++
             }
             if (i == 2) {
-                day = 'tomorrow';
+                day = $.mage.__('tomorrow');
             } else {
                 day = this.getDayWhenStoreOpen(indexCurrNexDate);
             }


### PR DESCRIPTION
Hey,

Currently shop status strings are hardcoded in prepareShopStatus() method from view/frontend/web/js/map-mixin.js
I might not think it through, but i used mage/translate component where i needed terms to be translated, nothing more.

Let me know what you think of this

Regards