### PR TITLE
Make extension compatible with php 8.0+

### DIFF
--- a/Model/Data/RetailerTimeSlot.php
+++ b/Model/Data/RetailerTimeSlot.php
@@ -69,7 +69,7 @@ class RetailerTimeSlot extends DataObject implements RetailerTimeSlotInterface, 
      *        which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed
     {
         return [
             'start_time' => $this->getStartTime(),

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "php": ">=8.0",
         "magento/framework": "*",
         "magento/module-store": "*",
         "magento/module-contact": "*",


### PR DESCRIPTION
mixed as a return type has been added as of php 8.0 
https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.mixed
and it has also been added to the JsonSerializable interface https://www.php.net/manual/en/class.jsonserializable.php
causing type errors if it is not added