### PR TITLE
Fix compatibility with php8.1 and magento2.4.4

### DIFF
--- a/Block/Search.php
+++ b/Block/Search.php
@@ -171,6 +171,7 @@ class Search extends \Magento\Framework\View\Element\Template implements Identit
             \Magento\Framework\Profiler::start('SmileStoreLocator:STORES');
             /** @var RetailerInterface $retailer */
             $imageUrlRetailer = $this->getImageUrl().'seller/';
+            $markers = [];
             foreach ($collection as $retailer) {
                 $address = $retailer->getExtensionAttributes()->getAddress();
                 \Magento\Framework\Profiler::start('SmileStoreLocator:STORES_DATA');

--- a/Model/Data/RetailerTimeSlot.php
+++ b/Model/Data/RetailerTimeSlot.php
@@ -69,7 +69,7 @@ class RetailerTimeSlot extends DataObject implements RetailerTimeSlotInterface, 
      *        which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'start_time' => $this->getStartTime(),

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "magento/module-contact": "*",
         "smile/module-map": "~1.1.0 || ~2.0",
         "smile/module-retailer": "~1.2.0",
-        "willdurand/geocoder": "^3.3"
+        "willdurand/geocoder": "^4.0"
     },
     "require-dev": {
         "smile/magento2-smilelab-quality-suite": "1.0.0"

--- a/view/adminhtml/web/js/component/retailer/opening-hours.js
+++ b/view/adminhtml/web/js/component/retailer/opening-hours.js
@@ -13,8 +13,7 @@
 
 define([
     'Magento_Ui/js/form/components/html',
-    'jquery',
-    'MutationObserver'
+    'jquery'
 ], function (Component, $) {
     'use strict';
 

--- a/view/adminhtml/web/js/elessar/elessar.js
+++ b/view/adminhtml/web/js/elessar/elessar.js
@@ -64,6 +64,10 @@
     var has = Object.prototype.hasOwnProperty;
 
     module.exports = function getEventProperty(prop, event) {
+        if (event.originalEvent && event.originalEvent.clientX && typeof event.originalEvent.clientX !== undefined) {
+            return event.originalEvent.clientX;
+        }
+
         return has.call(event, prop) ? event[prop]
             : event.originalEvent && event.originalEvent.touches ? event.originalEvent.touches[0][prop]
             : undefined;


### PR DESCRIPTION
**Description (*)**

Fix compatibility with php8.1 and magento2.4.4, update dependency module "willdurand/geocoder".

When editing or creating new retailer on sections "Opening Hours" and "Special Opening Hours" time slider doesn't work.

Please check this magento commit https://github.com/magento/magento2/commit/ca98c3a930bbd876ea2d62c17184472c60581b74
Magento deleted MutationObserver js file.

**Related Pull Requests**

https://github.com/Smile-SA/magento2-module-store-locator/pull/141

**Fixed Issues (if relevant)**

1. dependency module "willdurand/geocoder"
2. compatibility conversation with php8.1
3. "Opening Hours" and "Special Opening Hours" time slider doesn't work

**Manual testing scenarios (*)**

- Install module using composer 
- Make setup:di:compile

1. Login to admin
2. Go to Sellers -> Retailers
3. Create new or edit exist retailer
4. go to the section "Opening Hours"
5. Try to add or change opening hours by slider

**Questions or comments**