### PR TITLE
Fix RetailerTimeSlot file

### DIFF
--- a/Model/Data/RetailerTimeSlot.php
+++ b/Model/Data/RetailerTimeSlot.php
@@ -69,7 +69,7 @@ class RetailerTimeSlot extends DataObject implements RetailerTimeSlotInterface, 
      *        which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'start_time' => $this->getStartTime(),

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+	"php": "~8.0",
         "magento/framework": "*",
         "magento/module-store": "*",
         "magento/module-contact": "*",


### PR DESCRIPTION
* Make module compatible with Magento 2.4.5
* Add return type to function to match with parent function in native interface
BEWARE : This commit breaks previous compatibility (< PHP 8.X)