### PR TITLE
Explicitly set YYYY-MM-dd format for Zend_Date constructor

### DIFF
--- a/Block/Adminhtml/Retailer/OpeningHours/Element/Renderer.php
+++ b/Block/Adminhtml/Retailer/OpeningHours/Element/Renderer.php
@@ -160,7 +160,7 @@ class Renderer extends Template implements RendererInterface
         $values = [];
         if ($this->element->getValue()) {
             foreach ($this->element->getValue() as $timeSlot) {
-                $date   = new Zend_Date($this->date->date()->format('Y-m-d'));
+                $date   = new Zend_Date($this->date->date()->format('Y-m-d'), 'YYYY-MM-dd');
                 $startTime = $date->setTime($timeSlot->getStartTime(), 'h:mm a')->toString(DateTime::DATETIME_INTERNAL_FORMAT);
                 $endTime   = $date->setTime($timeSlot->getEndTime(), 'h:mm a')->toString(DateTime::DATETIME_INTERNAL_FORMAT);
                 $values[]  = [$startTime, $endTime];


### PR DESCRIPTION
In the Adminhtml's `Renderer.php`, the call of `$this->date->date()->format('Y-m-d')` correctly returns the string `2023-02-06` for today, February 6th of 2023. However, in installations with a different locale (like `de_DE`), this is wrongly interpreted as June 2nd of 2023 by the `Zend_Date()` constructor. For every date that might possibly be parsed both ways, this results in the problems described in #91 and #124: the set opening hours are incorrectly displayed at the very right of the range bar. If you look closely, you will notice that this problem was reported to be "magically gone" only after the 12th day of a month has passed, since this takes away the ambiguity in the date parsing process.

This PR explicitly states the date format of the given string, so it is parsed correctly independently on the set locale. It is more straightforward than my original proposal from three years ago in https://github.com/Smile-SA/magento2-module-store-locator/issues/91#issue-578937698.