### PR TITLE
Add missing declaration of class variable $timeSlotFactory

### DIFF
--- a/Model/Data/RetailerTimeSlotConverter.php
+++ b/Model/Data/RetailerTimeSlotConverter.php
@@ -25,6 +25,11 @@ use Smile\StoreLocator\Api\Data\RetailerTimeSlotInterfaceFactory;
 class RetailerTimeSlotConverter
 {
     /**
+     * @var RetailerTimeSlotInterfaceFactory
+     */
+    private $timeSlotFactory;
+
+    /**
      * RetailerTimeSlotConverter constructor.
      *
      * @param RetailerTimeSlotInterfaceFactory $timeSlotFactory Time Slot Factory


### PR DESCRIPTION
Without, PHP 8.2 throws the following exception:

```
Exception #0 (Exception): Deprecated Functionality: Creation of dynamic property Smile\StoreLocator\Model\Data\RetailerTimeSlotConverter::$timeSlotFactory is deprecated in vendor/smile/module-store-locator/Model/Data/RetailerTimeSlotConverter.php on line 34
```