### PR TITLE
Retrocompatibility of extension attributes with future webapi

### DIFF
--- a/Plugin/Rest/PrepareOffload.php
+++ b/Plugin/Rest/PrepareOffload.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\StoreLocator\Plugin\Rest;
+
+use Smile\Retailer\Api\Data\RetailerInterface;
+use Smile\Retailer\Model\RetailerRepository;
+use Smile\StoreLocator\Api\Data\RetailerTimeSlotInterface;
+use Smile\StoreLocator\Api\Data\RetailerTimeSlotInterfaceFactory;
+
+/**
+ * Plugin to save retailer extension attribut from rest
+ */
+class PrepareOffload
+{
+    public function __construct(
+        private RetailerTimeSlotInterfaceFactory $timeSlotFactory
+    ) {
+    }
+
+    /**
+     * The save handler offload attribute.
+     *
+     * It expects to have them loaded properly.
+     */
+    public function beforeSave(RetailerRepository $subject, RetailerInterface $retailer): void
+    {
+        $retailer->setAddress($retailer->getExtensionAttributes()->getAddress());
+
+        if (is_array($retailer->getExtensionAttributes()->getOpeningHours())) {
+            $retailer->setOpeningHours($this->convertSchedule($retailer->getExtensionAttributes()->getOpeningHours()));
+        }
+
+        if (is_array($retailer->getExtensionAttributes()->getSpecialOpeningHours())) {
+            $retailer->setSpecialOpeningHours(
+                $this->convertSchedule(
+                    $retailer->getExtensionAttributes()->getSpecialOpeningHours()
+                )
+            );
+        }
+    }
+
+    /**
+     * Convert JSON AM/PM hours to schedule structure
+     */
+    public function convertSchedule(array $mixedValue): array
+    {
+        $openingHours = json_decode($mixedValue[0], true);
+        foreach ($openingHours as $workingDay => $schedule) {
+            $openingHours[$workingDay] = array_map([$this, "createTimeSlotObject"], $schedule);
+        }
+        return $openingHours;
+    }
+
+    /**
+     * Convert AM/PM hours to date
+     */
+    public function createTimeSlotObject(array $slot): RetailerTimeSlotInterface
+    {
+        return $this->timeSlotFactory->create(
+            [
+                'data' => [
+                    'start_time' => date("G:i", strtotime($slot['start_time'])),
+                    'end_time' => date("G:i", strtotime($slot['end_time'])),
+                ],
+            ]
+        );
+    }
+}

--- a/Plugin/Rest/SerializeTimeslot.php
+++ b/Plugin/Rest/SerializeTimeslot.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\StoreLocator\Plugin\Rest;
+
+use Smile\StoreLocator\Model\Data\RetailerTimeSlotConverter;
+
+/**
+ * Plugin to load retailer extension attribute for rest usage
+ */
+class SerializeTimeslot
+{
+    /**
+     * Encode slots to json
+     *
+     * @param $subject
+     * @param array $openingHours
+     * @return array encoded time slots
+     */
+    public function afterToEntity(RetailerTimeSlotConverter $subject, mixed $openingHours): array
+    {
+        $res = json_encode($openingHours, JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE);
+        return [$res];
+    }
+}

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -16,7 +16,7 @@
                 <field>longitude</field>
             </join>
         </attribute>
-        <attribute code="opening_hours" type="Smile\StoreLocator\Api\Data\RetailerTimeSlotInterface[]"/>
-        <attribute code="special_opening_hours" type="Smile\StoreLocator\Api\Data\RetailerTimeSlotInterface[]"/>
+        <attribute code="opening_hours" type="mixed"/>
+        <attribute code="special_opening_hours" type="mixed"/>
     </extension_attributes>
 </config>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Smile\StoreLocator\Model\Data\RetailerTimeSlotConverter">
+        <plugin name="retailer_serialize_timeslot" type="Smile\StoreLocator\Plugin\Rest\SerializeTimeslot"/>
+    </type>
+    <type name="Smile\Retailer\Model\RetailerRepository">
+        <plugin name="retailer_prepare_offload" type="Smile\StoreLocator\Plugin\Rest\PrepareOffload"/>
+    </type>
+</config>


### PR DESCRIPTION
Hi,

The retailer "schedule" structure seems heavily inspired from the HTML representation of the calendar. This is not a problem when it is a admin controller which handle this, but it will be difficult to serialize and unserialize it, in particular in webapis.
This merge request is not a refactoring, but only a small fix to make it work with future webapi.
A full refactoring and a correct definition can be found in #148.

Regards,
Pascal Noisette
 